### PR TITLE
docs!: change documentation policy

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,3 +10,9 @@ disable=C0116, RST203, RST301
 
 [MASTER]
 ignore=conf.py
+
+[DESIGN]
+# Minimum number of public methods for a class (see R0903). Default is 2.
+# We decrease this to 1, since some interface classes just have a single
+# (public) method
+min-public-methods=1

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
+    'sphinx_autodoc_typehints',
 ]
 exclude_patterns = [
     '*build',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,7 +60,7 @@ autodoc_default_options = {
     'members': True,
     'undoc-members': True,
     'show-inheritance': True,
-    'special-members': '__init__, __call__, __eq__',
+    'special-members': '__call__, __eq__',
 }
 html_copy_source = False  # do not copy rst files
 html_show_copyright = False

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx==2.4.4
+sphinx-autodoc-typehints==1.10.3
 sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ ignore =
     D102 # method docstring
     D103 # function docstring
     D107 # init docstring
+    RST301 # unexpected indentation (related to google style docstring)
     W503
 application-import-names = tensorwaves
 rst-roles =

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ exclude =
     doc/conf.py
 ignore =
     D102 # method docstring
+    D103 # function docstring
     D107 # init docstring
     W503
 application-import-names = tensorwaves


### PR DESCRIPTION
This commit remove the need to write redundant docstrings everywhere.

- [x] Render type hints as parameters and return type in Sphinx documentation
- [x] Remove `__init__` from `special-members` (i.e. merge documentation with class entry)
- [x] Remove `pylint` checks on method docstrings --> already added `C0116`, see [this discussion](https://stackoverflow.com/questions/7877522/how-do-i-disable-missing-docstring-warnings-at-a-file-level-in-pylint)
- [x] Remove `flake8` checks on function docstrings.