### PR TITLE
ci: fix Sphinx linkcheck issues

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,6 +88,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
 ]
 exclude_patterns = [
@@ -113,6 +114,7 @@ html_show_sphinx = False
 html_theme = "sphinx_rtd_theme"
 pygments_style = "sphinx"
 todo_include_todos = False
+viewcode_follow_imported_members = True
 
 # Cross-referencing configuration
 default_role = "py:obj"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,7 +88,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
-    "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
 ]
 exclude_patterns = [
@@ -114,7 +113,6 @@ html_show_sphinx = False
 html_theme = "sphinx_rtd_theme"
 pygments_style = "sphinx"
 todo_include_todos = False
-viewcode_follow_imported_members = False
 
 # Cross-referencing configuration
 default_role = "py:obj"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,7 +129,7 @@ nitpick_ignore = [
 # Intersphinx settings
 intersphinx_mapping = {
     "expertsystem": (
-        "https://pwa.readthedocs.io/projects/expertsystem/en/latest/",
+        "https://pwa.readthedocs.io/projects/expertsystem/en/0.0-alpha1/",
         None,
     ),
     "iminuit": ("https://iminuit.readthedocs.io/en/latest/", None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -114,7 +114,7 @@ html_show_sphinx = False
 html_theme = "sphinx_rtd_theme"
 pygments_style = "sphinx"
 todo_include_todos = False
-viewcode_follow_imported_members = True
+viewcode_follow_imported_members = False
 
 # Cross-referencing configuration
 default_role = "py:obj"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,6 +4,6 @@ matplotlib>=3
 nbsphinx==0.5.1
 pandas>=1
 sphinx-autodoc-typehints>=1.10.3
-sphinx>=2.4.4
+sphinx>=2.4.4,<3.1
 sphinx_rtd_theme
 sphobjinv>=2.0.1

--- a/examples/jupyter/generate.ipynb
+++ b/examples/jupyter/generate.ipynb
@@ -34,8 +34,8 @@
    "source": [
     "import yaml\n",
     "\n",
-    "fc = open(\"../intensity-recipe.yaml\")\n",
-    "recipe = yaml.load(fc.read(), Loader=yaml.SafeLoader)"
+    "with open(\"../intensity-recipe.yaml\") as input_file:\n",
+    "    recipe = yaml.load(input_file.read(), Loader=yaml.SafeLoader)"
    ]
   },
   {


### PR DESCRIPTION
## Aim of the PR
Fix the Sphinx error that Travis emits since https://github.com/ComPWA/tensorwaves/pull/74 (see [this Travis job](https://travis-ci.com/github/ComPWA/tensorwaves/jobs/351326126)).

## Findings
- Failed job is **not** caused by [`sphinx-copybutton`](https://pypi.org/project/sphinx-copybutton/)
- Warning "`sphinx.util.inspect.Signature() is deprecated`" is emitted [when using Sphinx 3.1.1](https://travis-ci.com/github/ComPWA/tensorwaves/jobs/351376538#L664) instead of Sphinx 2.4.4
- "`WARNING: 'viewcode' reference target not found: _modules/tensorwaves/data/generate`" not fixed when setting `viewcode_follow_imported_members = False` (4e3d81b801503e1f59bf15f81eaf578eec276ccd)
- [`viewcode`](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) indeed causes the issue! (5714ab74edad25dc02301e0d309473ad1165a0a6) But removing that isn't a solution, because we want to be able to see the view the source code from the API
- At 1a5006d453132d41a59b1a648fc7c79dd2d1224a in the master branch, the warning [didn't occur](https://travis-ci.com/github/ComPWA/tensorwaves/jobs/336004234) yet. At the time, Travis used Sphinx 3.0.3.

## Outcome
Do not use Sphinx higher than 3.0
https://github.com/ComPWA/tensorwaves/blob/b753513a8fd4d6bb2cb9d0da4e88859eae33b013/doc/requirements.txt#L7