### PR TITLE
ci: set dev requirements to minimal

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,14 @@
 -r doc/requirements.txt
 -r tests/requirements.txt
-black==19.10b0
-flake8==3.7.9
+black>=19.10b0
 flake8-blind-except
 flake8-builtins
 flake8-docstrings
 flake8-import-order
 flake8-rst-docstrings
-mypy==0.770
+flake8>=3.7 # for per-file-ignores
+mypy>=0.770
 pep8-naming
-pre-commit==2.2.0
-pylint==2.4.4
-tox==3.14.6
+pre-commit>=2.2.0
+pylint>=2.4.4
+tox>=3.14.6

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-pytest>=5.4.1
 pytest-cov
+pytest>=5.4.1


### PR DESCRIPTION
Part 2 of #78 

This one doesn't fall under one of the points raised in #78, but I felt it necessary to keep in sync with the expertsystem.

Note that this also touches on #28 
