### PR TITLE
ci: make pydocstyle work in vscode

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,9 @@ init-import=yes
 
 [MESSAGES CONTROL]
 disable=
-    C0116,  # missing-function-docstring
+    C0114,  # done by pydocstyle
+    C0115,  # done by pydocstyle
+    C0116,  # done by pydocstyle
     C0330,  # for black formatting
     RST203,
     RST301,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,6 @@
   "python.linting.flake8Enabled": true,
   "python.linting.mypyArgs": ["--config-file=tox.ini"],
   "python.linting.mypyEnabled": true,
-  "python.linting.pydocstyleArgs": ["--match='(?!test_).*\\.py'"],
   "python.linting.pydocstyleEnabled": true,
   "python.linting.pylamaEnabled": false,
   "python.linting.pylintCategorySeverity.refactor": "Information",

--- a/tests/data/test_generate.py
+++ b/tests/data/test_generate.py
@@ -1,5 +1,3 @@
-"""Tests the generate facade functions."""
-
 import pytest
 
 from tensorwaves.data.generate import generate_phsp

--- a/tests/physics/helicityformalism/test_amplitude.py
+++ b/tests/physics/helicityformalism/test_amplitude.py
@@ -1,5 +1,3 @@
-"""Test helicity amplitude components."""
-
 import numpy as np
 
 import pytest  # type: ignore

--- a/tests/physics/helicityformalism/test_canonical.py
+++ b/tests/physics/helicityformalism/test_canonical.py
@@ -1,5 +1,3 @@
-"""Test helicity amplitude components."""
-
 import math
 
 import pytest  # type: ignore
@@ -42,7 +40,7 @@ from tensorwaves.physics.helicityformalism.amplitude import (
         ),
     ],
 )
-def test_clebsch_gordan_coefficent(test_recipe, expected_value):
+def test_clebsch_gordan_coefficient(test_recipe, expected_value):
     cgc = _clebsch_gordan_coefficient(test_recipe)
     assert cgc == pytest.approx(expected_value, rel=1e-6)
 

--- a/tests/physics/helicityformalism/test_helicityangles.py
+++ b/tests/physics/helicityformalism/test_helicityangles.py
@@ -1,5 +1,3 @@
-"""Tests regarding the helicity kinematics."""
-
 import numpy as np
 
 import pytest
@@ -124,7 +122,6 @@ TEST_DATA = {
 def test_helicity_angles_correctness(
     kinematics_recipe, test_events, expected_angles
 ):
-    """Test the correctness of the helicity theta and phi angles."""
     subsys_angle_names = {}
     kin = HelicityKinematics.from_recipe(kinematics_recipe)
     for subsys in expected_angles.keys():

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -1,0 +1,4 @@
+; ignore all pydocstyle errors in this folder
+
+[pydocstyle]
+add_ignore = D

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,6 @@ add_ignore =
     D203, # conflicts with D211
     D213, # multi-line docstring should start at the second line
     D407, # missing dashed underline after section
-match = (?!test).*\.py
 
 [pytest]
 addopts =

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ convention=google
 add_ignore =
     D102, # method docstring
     D103, # function docstring
+    D105, # magic method docstring
     D107, # init docstring
     D203, # conflicts with D211
     D213, # multi-line docstring should start at the second line


### PR DESCRIPTION
`pydocstyle` linting in vscode didn't work correctly, probably because of the `pydocstyle` args provided through `.vscode/settings.json`:
https://github.com/ComPWA/tensorwaves/blob/0c8c706f268d127c2ecfaeeb7b06cab22daf00b8/.vscode/settings.json#L26
This PR introduces another way to ignore docstrings in the tests folder that works for both linting from the terminal and in vscode.