### PR TITLE
feat: add analytical continuation for Breit Wigner

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 [options]
 python_requires = >=3.6, <3.8
 install_requires =
-    amplitf==0.0.1a
+    amplitf==0.0.1a2
     iminuit==1.4.5
     numpy==1.19.0
     phasespace==1.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 [options]
 python_requires = >=3.6, <3.8
 install_requires =
-    amplitf==0.0a1
+    amplitf==0.0.1a
     iminuit==1.4.5
     numpy==1.19.0
     phasespace==1.1.1


### PR DESCRIPTION
Implements analytical continuation below threshold for the BreitWigner function. It uses the new amplitf two body momentum function to sidestep a lot of complex valued computations.