### PR TITLE
fix: remove conda-forge from channels

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: tw
 channels:
-  - conda-forge
   - defaults
 dependencies:
   - python>=3.7


### PR DESCRIPTION
Conda Forge is not needed, because the default channel already supplies Python and pip. In fact, conda-forge causes problems now, because it seems to default to Python 3.9 (which TF does not support).