### PR TITLE
feat: return data samples as pandas.DataFrame

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -113,6 +113,7 @@
         "genindex",
         "heli",
         "histtype",
+        "hstack",
         "iminuit",
         "isort",
         "jupyterlab",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,7 @@ default_role = "py:obj"
 primary_domain = "py"
 nitpicky = True  # warn if cross-references are missing
 nitpick_ignore = [
+    ("py:class", "pandas.core.frame.DataFrame"),
     ("py:class", "tensorflow.keras.losses.Loss"),
     ("py:class", "tensorflow.python.keras.losses.Loss"),
     ("py:obj", "Loss"),

--- a/src/tensorwaves/data/__init__.py
+++ b/src/tensorwaves/data/__init__.py
@@ -1,8 +1,127 @@
+# cspell:ignore fillna
+
 """The data module takes care of data generation."""
 
 __all__ = [
     "generate",
     "tf_phasespace",
+    "PwaAccessor",
 ]
 
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
 from . import generate, tf_phasespace
+from ._data_frame import ENERGY_LABEL, MOMENTUM_LABELS, WEIGHT_LABEL
+
+
+@pd.api.extensions.register_dataframe_accessor("pwa")
+class PwaAccessor:
+    """`~pandas.DataFrame` accessor for PWA properties.
+
+    Additional namespace to interpret a `~pandas.DataFrame` as 'PWA style'
+    dataframe, see `here
+    <https://pandas.pydata.org/pandas-docs/stable/development/extending.html#registering-custom-accessors>`_.
+    """
+
+    def __init__(self, pandas_object: pd.DataFrame) -> None:
+        self._validate(pandas_object)
+        self._obj = pandas_object
+
+    @staticmethod
+    def _validate(obj: pd.DataFrame) -> None:
+        columns = obj.columns
+        if isinstance(columns, pd.MultiIndex):
+            # if multicolumn, test if 2 levels
+            columns = columns.levels
+            if len(obj.columns.levels) != 2:
+                raise IOError(
+                    "Not a PWA data data frame!\n"
+                    "pandas.DataFrame must have multicolumns of 2 levels:\n"
+                    " - 1st level are the particles names\n"
+                    " - 2nd level define the 4-momentum:"
+                    f"{MOMENTUM_LABELS}"
+                )
+            # then select 2nd columns only
+            columns = columns[1]
+        # Check if (sub)column names are same as momentum labels
+        if not set(MOMENTUM_LABELS) <= set(columns):
+            raise IOError(f"Columns must be {MOMENTUM_LABELS}")
+
+    @property
+    def weights(self) -> Optional[pd.DataFrame]:
+        """Get list of weights, if available."""
+        if WEIGHT_LABEL not in self.column_names:
+            return None
+        return self._obj[WEIGHT_LABEL]
+
+    @property
+    def intensities(self) -> Optional[pd.DataFrame]:
+        """Alias for :func:`weights` in the case of a fit intensity sample."""
+        return self.weights
+
+    @property
+    def column_names(self) -> list:
+        """Get a list of the top layer column names."""
+        columns = self._obj.columns
+        if isinstance(columns, pd.MultiIndex):
+            columns = self._obj.columns.droplevel(1).unique()
+        return columns.to_list()
+
+    @property
+    def particles(self) -> Optional[List[str]]:
+        """Get list of non-particle columns contained in the data frame."""
+        columns = self._obj.columns
+        if not isinstance(columns, pd.MultiIndex):
+            return None
+        return [
+            col
+            for col in self.column_names
+            if isinstance(self._obj[col], pd.DataFrame)
+            and self._obj[col].columns.unique().to_list() == MOMENTUM_LABELS
+        ]
+
+    @property
+    def energy(self) -> pd.DataFrame:
+        """Get a dataframe containing only the energies."""
+        if isinstance(self._obj.columns, pd.MultiIndex):
+            return self._obj.xs(ENERGY_LABEL, level=1, axis=1)
+        return self._obj[ENERGY_LABEL]
+
+    @property
+    def p4sum(self) -> pd.DataFrame:
+        """Get the total 4-momenta of the particles."""
+        return self._obj.sum(
+            axis=1,
+            level=len(self._obj.columns.names) - 1,
+        )
+
+    @property
+    def p_xyz(self) -> pd.DataFrame:
+        """Get a dataframe containing only the 3-momenta."""
+        return self._obj.filter(regex=("p_[xyz]"))
+
+    @property
+    def rho2(self) -> pd.DataFrame:
+        """**Compute** quadratic sum of the 3-momenta."""
+        if isinstance(self._obj.columns, pd.MultiIndex):
+            return (self.p_xyz ** 2).sum(axis=1, level=0)
+        return (self.p_xyz ** 2).sum(axis=1)
+
+    @property
+    def rho(self) -> pd.DataFrame:
+        """**Compute** absolute value of the 3-momenta."""
+        return np.sqrt(self.rho2)
+
+    @property
+    def mass2(self) -> pd.DataFrame:
+        """**Compute** the square of the invariant masses."""
+        mass2 = self.energy ** 2 - self.rho2
+        return abs(mass2.fillna(0))
+
+    @property
+    def mass(self) -> pd.DataFrame:
+        """**Compute** the invariant masses."""
+        return np.sqrt(self.mass2)

--- a/src/tensorwaves/data/_data_frame.py
+++ b/src/tensorwaves/data/_data_frame.py
@@ -1,0 +1,48 @@
+"""Functions for creating a correctly formatted `pandas.DataFrame`.
+
+This module is a sub-module so that it is available for modules like
+`.data.generate` without creating cycling dependencies. It offers functionality
+to create `~.pandas.DataFrame` s that comply the :code:`_validate` method of
+the `.PwaAccessor`.
+"""
+
+
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+ENERGY_LABEL = "E"
+MOMENTUM_LABELS = ["p_x", "p_y", "p_z", ENERGY_LABEL]
+WEIGHT_LABEL = "weight"
+
+
+def create_frame(
+    data: Sequence,
+    column_names: Iterable,
+) -> pd.DataFrame:
+    """Create an `PWA DataFrame <.PwaAccessor>`.
+
+    The columns of the `~pandas.DataFrame` are specially formatted so that they
+    agree with the :code:`_validate` method of the `.PwaAccessor`.
+    """
+    multi_column = create_multicolumn(column_names)
+    return pd.DataFrame(
+        data=data,
+        columns=multi_column,
+    )
+
+
+def create_multicolumn(column_names: Iterable) -> pd.Index:
+    """Create a multicolumn.
+
+    The multicolumn complies with the complies with the standards set by the
+    `~.PwaAccessor`.
+    """
+    cols = [
+        (top_column, mom)
+        for top_column in column_names
+        for mom in MOMENTUM_LABELS
+    ]
+    return pd.MultiIndex.from_tuples(
+        tuples=cols, names=["StateID", "Momentum"]
+    )

--- a/src/tensorwaves/data/generate.py
+++ b/src/tensorwaves/data/generate.py
@@ -35,15 +35,21 @@ def _generate_data_bunch(
     phsp_sample, weights = phsp_generator.generate(
         bunch_size, random_generator
     )
-    dataset = kinematics.convert(phsp_sample)
+    phsp_frame = __np_events_to_pandas(
+        phsp_sample, kinematics._reaction_info  # type: ignore
+    )
+    dataset = kinematics.convert(phsp_frame)
     intensities = intensity(dataset)
     maxvalue = np.max(intensities)
 
     uniform_randoms = random_generator(bunch_size, max_value=maxvalue)
 
     phsp_sample = phsp_sample.transpose(1, 0, 2)
-
-    return (phsp_sample[weights * intensities > uniform_randoms], maxvalue)
+    selected_events = phsp_sample[weights * intensities > uniform_randoms]
+    data_frame = __np_events_to_pandas(
+        selected_events, kinematics.reaction_info  # type: ignore
+    )
+    return (data_frame, maxvalue)
 
 
 def generate_data(
@@ -55,7 +61,7 @@ def generate_data(
     ] = TFPhaseSpaceGenerator,
     random_generator: Optional[UniformRealNumberGenerator] = None,
     bunch_size: int = 50000,
-) -> np.ndarray:
+) -> pd.DataFrame:
     """Facade function for creating data samples based on an intensities.
 
     Args:

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -1,0 +1,75 @@
+# pylint: disable=no-self-use
+
+import numpy as np
+import pandas as pd
+import pytest
+from expertsystem.amplitude.model import AmplitudeModel
+
+from tensorwaves.data._data_frame import MOMENTUM_LABELS, WEIGHT_LABEL
+from tensorwaves.data.generate import generate_phsp
+from tensorwaves.physics.helicity_formalism.kinematics import (
+    HelicityKinematics,
+)
+
+
+class TestPwaAccessor:
+    @staticmethod
+    def test_properties(helicity_model: AmplitudeModel):
+        model = helicity_model
+        kinematics = HelicityKinematics.from_model(model)
+        n_events = 100
+        sample = generate_phsp(n_events, kinematics)
+        assert pytest.approx(sample.pwa.mass.mean().to_list(), abs=1e-4) == [
+            0,
+            0.135,
+            0.135,
+        ]
+        assert sample.pwa.particles == [2, 3, 4]
+        assert sample.pwa.particles == sample.pwa.column_names
+        assert sample.pwa.weights is None
+        assert sample.pwa.intensities is None
+
+        weights = np.ones(n_events)
+        sample[WEIGHT_LABEL] = weights
+        assert (sample.pwa.weights == weights).all()
+        assert (sample.pwa.intensities == weights).all()
+
+        total_p4 = sample.pwa.p4sum
+        assert pytest.approx(total_p4.pwa.mass.mean(), abs=1e-6) == 3.0969
+
+        gamma_sample = sample[2]
+        assert gamma_sample.pwa.particles is None
+        assert gamma_sample.pwa.column_names == MOMENTUM_LABELS
+        assert pytest.approx(gamma_sample.pwa.mass.mean(), abs=1e-4) == 0
+        assert gamma_sample.equals(gamma_sample.pwa.p4sum)
+
+    @pytest.mark.parametrize(
+        "frame",
+        [
+            pd.DataFrame(
+                data=np.ones((3, 24)),
+                columns=pd.MultiIndex.from_tuples(
+                    [
+                        (col1, col2, mom)
+                        for col1 in ["col1_A", "col1_B"]
+                        for col2 in ["col2_A", "col2_B", "col2_C"]
+                        for mom in MOMENTUM_LABELS
+                    ]
+                ),
+            ),
+            pd.DataFrame(
+                data=np.ones((3, 9)),
+                columns=pd.MultiIndex.from_tuples(
+                    [
+                        (state_id, mom)
+                        for state_id in [2, 3, 4]
+                        for mom in MOMENTUM_LABELS[:3]
+                    ]
+                ),
+            ),
+            pd.DataFrame(data=np.ones((3, 2)), columns=["one", "two"]),
+        ],
+    )
+    def test_validator(self, frame: pd.DataFrame):
+        with pytest.raises(IOError):
+            assert frame.pwa.mass

--- a/tests/data/test_generate.py
+++ b/tests/data/test_generate.py
@@ -10,30 +10,27 @@ from tensorwaves.physics.helicity_formalism.kinematics import (
 
 
 @pytest.mark.parametrize(
-    "sample_size, initial_state_names, final_state_names, expected_shape",
+    "sample_size, initial_state_names, final_state_names",
     [
         (
             5000,
             "J/psi(1S)",
             ("pi0", "pi0", "pi0"),
-            (3, 5000, 4),
         ),
         (
             320,
             ("J/psi(1S)"),
             ("pi0", "pi0", "pi0", "gamma"),
-            (4, 320, 4),
         ),
         (
             250,
             "J/psi(1S)",
             ("pi0", "pi0", "pi0", "pi0", "gamma"),
-            (5, 250, 4),
         ),
     ],
 )
 def test_generate_phsp(
-    sample_size, initial_state_names, final_state_names, expected_shape, pdg
+    sample_size, initial_state_names, final_state_names, pdg
 ):
     reaction_info = ParticleReactionKinematicsInfo(
         initial_state_names=initial_state_names,
@@ -42,7 +39,7 @@ def test_generate_phsp(
     )
     kin = HelicityKinematics(reaction_info)
     sample = generate_phsp(sample_size, kin)
-    assert sample.shape == expected_shape
+    assert len(sample) == sample_size
 
 
 def test_generate_data(canonical_model: es.AmplitudeModel):

--- a/tests/physics/helicity_formalism/test_helicity_angles.py
+++ b/tests/physics/helicity_formalism/test_helicity_angles.py
@@ -2,6 +2,7 @@ import expertsystem.amplitude.model as es
 import numpy as np
 import pytest
 
+from tensorwaves.data._data_frame import create_frame
 from tensorwaves.physics.helicity_formalism.kinematics import (
     HelicityKinematics,
     SubSystem,
@@ -123,15 +124,16 @@ def test_helicity_angles_correctness(test_events, expected_angles, pdg):
         temp_names = kin.register_subsystem(SubSystem(*subsys))
         subsys_angle_names.update({subsys: [temp_names[1], temp_names[2]]})
 
-    data = np.array(tuple(np.array(v) for v in test_events.values()))
+    data = create_frame(
+        np.hstack(np.array(list(test_events.values()))),
+        column_names=test_events.keys(),
+    )
     kinematic_vars = kin.convert(data)
 
-    assert len(kinematic_vars) == 3 * len(expected_angles.keys())
+    assert len(kinematic_vars.columns) == 3 * len(expected_angles.keys())
     number_of_events = len(data[0])
     for subsys, angle_names in subsys_angle_names.items():
-        for name in angle_names:
-            assert len(kinematic_vars[name]) == number_of_events
-
+        assert len(kinematic_vars) == number_of_events
         expected_values = np.array(np.array(expected_angles[subsys]).T)
         # test cos(theta)
         np.testing.assert_array_almost_equal(

--- a/tests/recipe/test_amplitude_creation.py
+++ b/tests/recipe/test_amplitude_creation.py
@@ -29,7 +29,8 @@ def test_helicity(helicity_model: es.AmplitudeModel):
     assert masses_fs == [0.0, 0.1349768, 0.1349768]
 
     phsp_sample = _generate_phsp(model, NUMBER_OF_PHSP_EVENTS)
-    assert phsp_sample.shape == (3, NUMBER_OF_PHSP_EVENTS, 4)
+    assert len(phsp_sample) == NUMBER_OF_PHSP_EVENTS
+    assert len(phsp_sample.pwa.particles) == 3
 
     builder = IntensityBuilder(model.particles, kinematics, phsp_sample)
     intensity = builder.create_intensity(model)


### PR DESCRIPTION
@spflueger Here's an attempt to return `pandas.DataFrame` instead of a `numpy.array`. Works fine for the tests, but I get in trouble with the `IntensityTF` call. This is not tested, so we may want to write some tests for `generate_data` first.