### PR TITLE
fix: only determine doc version if available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,9 @@ project = "TensorWaves"
 copyright = "2020, ComPWA"
 author = "Common Partial Wave Analysis"
 
-__release = get_distribution("tensorwaves").version
-version = ".".join(__release.split(".")[:3])
+if os.path.exists("../src/tensorwaves/version.py"):
+    __release = get_distribution("tensorwaves").version
+    version = ".".join(__release.split(".")[:3])
 
 # -- Generate API skeleton ----------------------------------------------------
 shutil.rmtree("api", ignore_errors=True)


### PR DESCRIPTION
Fixes a small bug that is annoying when building the docs after cleaning the repo (e.g. using `git clean`).