### PR TITLE
ci: improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,26 +1,32 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG] "
-labels: bug
+title: ""
+labels: Bug
 assignees: ""
 ---
 
-**Describe the bug** A clear and concise description of what the bug is.
+## Bug description
 
-**To Reproduce** Steps to reproduce the behavior:
+<!-- A clear and concise description of what the bug is. -->
+
+<!-- If applicable, add a log or screenshot to help explain your problem. -->
+
+## How to reproduce?
+
+Steps to reproduce the behavior:
 
 1.
 
-**Expected behavior** A clear and concise description of what you expected to
-happen.
+## Expected behavior
 
-**Error log** If applicable, add an error log or screenshots to help explain
-your problem.
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Desktop (please complete the following information):**
+## System info
 
-- OS: [e.g. iOS]
-- Version [e.g. 22]
+Bug resulted on the following system:
 
-**Additional context** Add any other context about the problem here.
+- OS: <!-- e.g. macOS, WSL Ubuntu, ...-->
+- Version <!-- e.g. 10.15, 20.04, ... -->
+- Python version: <!-- e.g. 3.6, 3.7, ... -->
+- Virtual environment: <!-- e.g. venv, Conda, pip user install, ... -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,22 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[REQUEST] "
-labels: ""
+title: ""
+labels: "💡 Enhancement"
 assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.** A clear and
+## Problem description
+
+<!-- Is your feature request related to a problem? Please provide a clear and
 concise description of what the problem is. [Example: "I'm always frustrated
-when ..."]
+when ..." -->
 
-**Describe the solution you'd like** A clear and concise description of what
-you want to happen.
+## Proposed solution
 
-**Describe alternatives you've considered** A clear and concise description of
-any alternative solutions or features you've considered.
+<!-- Describe the solution you'd want to happen. -->
 
-**Additional context** Add any other context or screenshots about the feature
-request here.
+<!-- Are there alternatives you have considered? -->
+
+<!-- Additional context: -->
+<!-- Add any other context or screenshots about the feature -->


### PR DESCRIPTION
The issues templates still use the old issue labels. See also https://github.com/ComPWA/expertsystem/pull/420