### PR TITLE
refactor!: normalize function in NLL

### DIFF
--- a/docs/usage/2_generate_data.ipynb
+++ b/docs/usage/2_generate_data.ipynb
@@ -110,7 +110,7 @@
    "source": [
     "'Data samples' are more complicated than phase space samples in that they represent the intensity profile resulting from a reaction. You therefore need an [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) object (or, more generally, a [Function](tensorwaves.interfaces.Function) instance) and a phase space over which to generate that intensity distribution. We call such a data sample an **intensity-based sample**.\n",
     "\n",
-    "An intensity-based sample is generated with the function [generate_data](tensorwaves.data.generate.generate_data). Its usage is similar to [generate_phsp](tensorwaves.data.generate.generate_phsp), but now you have to give an [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) in addition to the [Kinematics](tensorwaves.interfaces.Kinematics) object. An [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) object can be created with the [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) class:"
+    "An intensity-based sample is generated with the function [generate_data](tensorwaves.data.generate.generate_data). Its usage is similar to [generate_phsp](tensorwaves.data.generate.generate_phsp), but now you have to give an [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) in addition to the [Kinematics](tensorwaves.interfaces.Kinematics) object. An [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) object can be created with the [IntensityBuilder](tensorwaves.physics.helicity_formalism.amplitude.IntensityBuilder) class:"
    ]
   },
   {
@@ -121,7 +121,7 @@
    "source": [
     "from tensorwaves.physics.helicity_formalism.amplitude import IntensityBuilder\n",
     "\n",
-    "builder = IntensityBuilder(model.particles, kin, phsp_sample)\n",
+    "builder = IntensityBuilder(model.particles, kin)\n",
     "intensity = builder.create_intensity(model)"
    ]
   },
@@ -218,7 +218,6 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "\n",
     "data_frame = pd.DataFrame(data_set)\n",
     "phsp_frame = pd.DataFrame(phsp_set)\n",
     "data_frame"

--- a/docs/usage/3_perform_fit.ipynb
+++ b/docs/usage/3_perform_fit.ipynb
@@ -65,7 +65,7 @@
    "source": [
     "To perform a fit, you need to define an **estimator**. An estimator is a measure for the discrepancy between the intensity model and the data distribution to which you fit. In PWA, we usually use an *unbinned negative log likelihood estimator*, which can be created as follows with the [tensorwaves.estimator](tensorwaves.estimator) module.\n",
     "\n",
-    "Generally the intensity model is not normalized, but a log likelihood estimator requires a normalized function. This is where the phase space dataset comes into play! The intensity is separately evaluated with the phase space dataset and the normalization is achieved in this way. It is a required argument! Note that if you want to correct for the efficiency of the detector, a detector reconstruced phase space dataset should be inserted here."
+    "Generally the intensity model is not normalized, but a log likelihood estimator requires a normalized function. This is where the phase space dataset comes into play! The intensity is separately evaluated with the phase space dataset and the normalization is achieved in this way. It is a required argument! Note that if you want to correct for the efficiency of the detector, a detector-reconstructed phase space dataset should be inserted here."
    ]
   },
   {

--- a/docs/usage/3_perform_fit.ipynb
+++ b/docs/usage/3_perform_fit.ipynb
@@ -46,7 +46,7 @@
     "kinematics = HelicityKinematics.from_model(model)\n",
     "data_sample = np.load(\"data_sample.npy\")\n",
     "phsp_sample = np.load(\"phsp_sample.npy\")\n",
-    "intensity_builder = IntensityBuilder(model.particles, kinematics, phsp_sample)\n",
+    "intensity_builder = IntensityBuilder(model.particles, kinematics)\n",
     "intensity = intensity_builder.create_intensity(model)\n",
     "phsp_set = kinematics.convert(phsp_sample)\n",
     "data_set = kinematics.convert(data_sample)"
@@ -63,7 +63,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To perform a fit, you need to define an **estimator**. An estimator is a measure for the discrepancy between the intensity model and the data distribution to which you fit. In PWA, we usually use an *unbinned negative log likelihood estimator*, which can be created as follows with the [tensorwaves.estimator](tensorwaves.estimator) module:"
+    "To perform a fit, you need to define an **estimator**. An estimator is a measure for the discrepancy between the intensity model and the data distribution to which you fit. In PWA, we usually use an *unbinned negative log likelihood estimator*, which can be created as follows with the [tensorwaves.estimator](tensorwaves.estimator) module.\n",
+    "\n",
+    "Generally the intensity model is not normalized, but a log likelihood estimator requires a normalized function. This is where the phase space dataset comes into play! The intensity is separately evaluated with the phase space dataset and the normalization is achieved in this way. It is a required argument! Note that if you want to correct for the efficiency of the detector, a detector reconstruced phase space dataset should be inserted here."
    ]
   },
   {
@@ -74,7 +76,7 @@
    "source": [
     "from tensorwaves.estimator import UnbinnedNLL\n",
     "\n",
-    "estimator = UnbinnedNLL(intensity, data_set)"
+    "estimator = UnbinnedNLL(intensity, data_set, phsp_set)"
    ]
   },
   {

--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -40,7 +40,7 @@ doc8==0.8.1
 docutils==0.16
 entrypoints==0.3
 execnet==1.7.1
-expertsystem==0.6.5
+expertsystem==0.6.6
 filelock==3.0.12
 flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -50,7 +50,7 @@ ipykernel==5.4.2
 ipython-genutils==0.2.0
 ipython==7.16.1
 ipywidgets==7.6.3
-jedi==0.18.0
+jedi==0.17.2
 jinja2==2.11.2
 jsonschema==3.2.0
 jupyter-cache==0.4.1

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -28,7 +28,7 @@ defusedxml==0.6.0
 dm-tree==0.1.5
 docutils==0.16
 entrypoints==0.3
-expertsystem==0.6.5
+expertsystem==0.6.6
 flatbuffers==1.12
 fuzzywuzzy==0.18.0
 gast==0.3.3
@@ -50,7 +50,7 @@ ipykernel==5.4.2
 ipython-genutils==0.2.0
 ipython==7.16.1
 ipywidgets==7.6.3
-jedi==0.17.2
+jedi==0.18.0
 jinja2==2.11.2
 jsonschema==3.2.0
 jupyter-cache==0.4.1

--- a/reqs/3.6/requirements-sty.txt
+++ b/reqs/3.6/requirements-sty.txt
@@ -27,7 +27,7 @@ dm-tree==0.1.5
 doc8==0.8.1
 docutils==0.16
 execnet==1.7.1
-expertsystem==0.6.5
+expertsystem==0.6.6
 filelock==3.0.12
 flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1

--- a/reqs/3.6/requirements-test.txt
+++ b/reqs/3.6/requirements-test.txt
@@ -18,7 +18,7 @@ cycler==0.10.0
 decorator==4.4.2
 dm-tree==0.1.5
 execnet==1.7.1
-expertsystem==0.6.5
+expertsystem==0.6.6
 flatbuffers==1.12
 gast==0.3.3
 google-auth-oauthlib==0.4.2

--- a/reqs/3.6/requirements.txt
+++ b/reqs/3.6/requirements.txt
@@ -14,7 +14,7 @@ chardet==4.0.0
 cloudpickle==1.6.0
 decorator==4.4.2
 dm-tree==0.1.5
-expertsystem==0.6.5
+expertsystem==0.6.6
 flatbuffers==1.12
 gast==0.3.3
 google-auth-oauthlib==0.4.2

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -38,7 +38,7 @@ doc8==0.8.1
 docutils==0.16
 entrypoints==0.3
 execnet==1.7.1
-expertsystem==0.6.5
+expertsystem==0.6.6
 filelock==3.0.12
 flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -49,7 +49,7 @@ ipykernel==5.4.2
 ipython-genutils==0.2.0
 ipython==7.19.0
 ipywidgets==7.6.3
-jedi==0.18.0
+jedi==0.17.2
 jinja2==2.11.2
 jsonschema==3.2.0
 jupyter-cache==0.4.1

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -28,7 +28,7 @@ defusedxml==0.6.0
 dm-tree==0.1.5
 docutils==0.16
 entrypoints==0.3
-expertsystem==0.6.5
+expertsystem==0.6.6
 flatbuffers==1.12
 fuzzywuzzy==0.18.0
 gast==0.3.3
@@ -49,7 +49,7 @@ ipykernel==5.4.2
 ipython-genutils==0.2.0
 ipython==7.19.0
 ipywidgets==7.6.3
-jedi==0.17.2
+jedi==0.18.0
 jinja2==2.11.2
 jsonschema==3.2.0
 jupyter-cache==0.4.1

--- a/reqs/3.7/requirements-sty.txt
+++ b/reqs/3.7/requirements-sty.txt
@@ -26,7 +26,7 @@ dm-tree==0.1.5
 doc8==0.8.1
 docutils==0.16
 execnet==1.7.1
-expertsystem==0.6.5
+expertsystem==0.6.6
 filelock==3.0.12
 flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1

--- a/reqs/3.7/requirements-test.txt
+++ b/reqs/3.7/requirements-test.txt
@@ -18,7 +18,7 @@ cycler==0.10.0
 decorator==4.4.2
 dm-tree==0.1.5
 execnet==1.7.1
-expertsystem==0.6.5
+expertsystem==0.6.6
 flatbuffers==1.12
 gast==0.3.3
 google-auth-oauthlib==0.4.2

--- a/reqs/3.7/requirements.txt
+++ b/reqs/3.7/requirements.txt
@@ -14,7 +14,7 @@ chardet==4.0.0
 cloudpickle==1.6.0
 decorator==4.4.2
 dm-tree==0.1.5
-expertsystem==0.6.5
+expertsystem==0.6.6
 flatbuffers==1.12
 gast==0.3.3
 google-auth-oauthlib==0.4.2

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -38,7 +38,7 @@ doc8==0.8.1
 docutils==0.16
 entrypoints==0.3
 execnet==1.7.1
-expertsystem==0.6.5
+expertsystem==0.6.6
 filelock==3.0.12
 flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -49,7 +49,7 @@ ipykernel==5.4.2
 ipython-genutils==0.2.0
 ipython==7.19.0
 ipywidgets==7.6.3
-jedi==0.18.0
+jedi==0.17.2
 jinja2==2.11.2
 jsonschema==3.2.0
 jupyter-cache==0.4.1

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -28,7 +28,7 @@ defusedxml==0.6.0
 dm-tree==0.1.5
 docutils==0.16
 entrypoints==0.3
-expertsystem==0.6.5
+expertsystem==0.6.6
 flatbuffers==1.12
 fuzzywuzzy==0.18.0
 gast==0.3.3
@@ -49,7 +49,7 @@ ipykernel==5.4.2
 ipython-genutils==0.2.0
 ipython==7.19.0
 ipywidgets==7.6.3
-jedi==0.17.2
+jedi==0.18.0
 jinja2==2.11.2
 jsonschema==3.2.0
 jupyter-cache==0.4.1

--- a/reqs/3.8/requirements-sty.txt
+++ b/reqs/3.8/requirements-sty.txt
@@ -26,7 +26,7 @@ dm-tree==0.1.5
 doc8==0.8.1
 docutils==0.16
 execnet==1.7.1
-expertsystem==0.6.5
+expertsystem==0.6.6
 filelock==3.0.12
 flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1

--- a/reqs/3.8/requirements-test.txt
+++ b/reqs/3.8/requirements-test.txt
@@ -18,7 +18,7 @@ cycler==0.10.0
 decorator==4.4.2
 dm-tree==0.1.5
 execnet==1.7.1
-expertsystem==0.6.5
+expertsystem==0.6.6
 flatbuffers==1.12
 gast==0.3.3
 google-auth-oauthlib==0.4.2

--- a/reqs/3.8/requirements.txt
+++ b/reqs/3.8/requirements.txt
@@ -14,7 +14,7 @@ chardet==4.0.0
 cloudpickle==1.6.0
 decorator==4.4.2
 dm-tree==0.1.5
-expertsystem==0.6.5
+expertsystem==0.6.6
 flatbuffers==1.12
 gast==0.3.3
 google-auth-oauthlib==0.4.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     amplitf
-    expertsystem == 0.6.5
+    expertsystem >= 0.6.6
     iminuit < 2.0
     numpy
     pandas

--- a/src/tensorwaves/estimator.py
+++ b/src/tensorwaves/estimator.py
@@ -2,10 +2,42 @@
 
 All estimators have to implement the `~.interfaces.Estimator` interface.
 """
+from typing import Dict
+
 import numpy as np
 import tensorflow as tf
 
 from tensorwaves.interfaces import Estimator, Function
+
+
+class _NormalizedFunction(Function):
+    def __init__(
+        self,
+        unnormalized_function: Function,
+        norm_dataset: dict,
+        norm_volume: float = 1.0,
+    ) -> None:
+        self._model = unnormalized_function
+        # it is crucial to convert the input data to tensors
+        # otherwise the memory footprint can increase dramatically
+        self._norm_dataset = {
+            x: tf.constant(y) for x, y in norm_dataset.items()
+        }
+        self._norm_volume = norm_volume
+
+    def __call__(self, dataset: dict) -> tf.Tensor:
+        normalization = tf.multiply(
+            self._norm_volume,
+            tf.reduce_mean(self._model(self._norm_dataset)),
+        )
+        return tf.divide(self._model(dataset), normalization)
+
+    @property
+    def parameters(self) -> Dict[str, tf.Variable]:
+        return self._model.parameters
+
+    def update_parameters(self, new_parameters: dict) -> None:
+        self._model.update_parameters(new_parameters)
 
 
 class UnbinnedNLL(Estimator):
@@ -15,11 +47,18 @@ class UnbinnedNLL(Estimator):
         model: A model that should be compared to the dataset.
         dataset: The dataset used for the comparison. The model has to be
             evaluateable with this dataset.
+        phsp_set: A phase space dataset, which is used for the normalization.
+            The model has to be evaluateable with this dataset. When correcting
+            for the detector efficiency use a phase space sample, that passed
+            the detector reconstruction.
 
     """
 
-    def __init__(self, model: Function, dataset: dict) -> None:
-        self.__model = model
+    def __init__(self, model: Function, dataset: dict, phsp_set: dict) -> None:
+        if phsp_set and len(phsp_set) > 0:
+            self.__model: Function = _NormalizedFunction(model, phsp_set)
+        else:
+            self.__model = model
         self.__dataset = dataset
 
     def __call__(self) -> float:

--- a/src/tensorwaves/physics/helicity_formalism/amplitude.py
+++ b/src/tensorwaves/physics/helicity_formalism/amplitude.py
@@ -542,7 +542,7 @@ def _clebsch_gordan_coefficient(clebsch_gordan: es.ClebschGordan) -> float:
 def _determine_canonical_prefactor(node: es.CanonicalDecay) -> float:
     l_s = _clebsch_gordan_coefficient(node.l_s)
     s2s3 = _clebsch_gordan_coefficient(node.s2s3)
-    return l_s * s2s3
+    return float(l_s * s2s3)
 
 
 def _create_helicity_decay(  # pylint: disable=too-many-locals

--- a/src/tensorwaves/physics/helicity_formalism/amplitude.py
+++ b/src/tensorwaves/physics/helicity_formalism/amplitude.py
@@ -159,6 +159,15 @@ class IntensityBuilder:
 
         kwargs = {}
         form_factor = getattr(decay_dynamics, "form_factor", None)
+        if (
+            form_factor is not None
+            and not dynamics_properties.orbit_angular_momentum.is_integer()
+        ):
+            raise ValueError(
+                "Model invalid! Using a non integer value for the orbital"
+                " angular momentum L. Seems like you are using the helicity"
+                " formalism, but should be using the canonical formalism"
+            )
         if isinstance(form_factor, es.BlattWeisskopf):
             kwargs.update({"form_factor": "BlattWeisskopf"})
             meson_radius_val = form_factor.meson_radius.value
@@ -613,13 +622,6 @@ def _create_dynamics(
     orbit_angular_momentum = particle.spin
     if isinstance(amplitude_node, es.CanonicalDecay):
         orbit_angular_momentum = amplitude_node.l_s.j_1
-    elif isinstance(amplitude_node, es.HelicityDecay):
-        if not orbit_angular_momentum.is_integer():
-            raise ValueError(
-                "Model invalid! Using a non integer value for the orbital"
-                " angular momentum L. Seems like you are using the helicity"
-                " formalism, but should be using the canonical formalism"
-            )
 
     dynamics = builder.create_dynamics(
         particle,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,11 @@ def phsp_sample(kinematics: HelicityKinematics) -> np.ndarray:
 
 
 @pytest.fixture(scope="session")
+def phsp_set(kinematics: HelicityKinematics, phsp_sample: np.ndarray) -> dict:
+    return kinematics.convert(phsp_sample)
+
+
+@pytest.fixture(scope="session")
 def intensity(
     helicity_model: AmplitudeModel,
     kinematics: HelicityKinematics,
@@ -91,8 +96,10 @@ def data_set(
 
 
 @pytest.fixture(scope="session")
-def estimator(intensity: IntensityTF, data_set: dict) -> UnbinnedNLL:
-    return UnbinnedNLL(intensity, data_set)
+def estimator(
+    intensity: IntensityTF, data_set: dict, phsp_set: dict
+) -> UnbinnedNLL:
+    return UnbinnedNLL(intensity, data_set, phsp_set)
 
 
 @pytest.fixture(scope="session")

--- a/tests/recipe/test_amplitude_creation.py
+++ b/tests/recipe/test_amplitude_creation.py
@@ -49,7 +49,6 @@ def test_helicity(helicity_model: es.AmplitudeModel):
         "Width_J/psi(1S)",
         "Width_f(0)(500)",
         "Width_f(0)(980)",
-        "strength_incoherent",
     }
 
 
@@ -75,5 +74,4 @@ def test_canonical(canonical_model: es.AmplitudeModel):
         "Width_J/psi(1S)",
         "Width_f(0)(500)",
         "Width_f(0)(980)",
-        "strength_incoherent",
     }

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -5,7 +5,6 @@ class TestUnbinnedNLL:
     @staticmethod
     def test_parameters(estimator: UnbinnedNLL):
         assert estimator.parameters == {
-            "strength_incoherent": 1.0,
             "MesonRadius_J/psi(1S)": 1.0,
             "MesonRadius_f(0)(500)": 1.0,
             "MesonRadius_f(0)(980)": 1.0,


### PR DESCRIPTION
The expertsystem was changed to not normalize the Intensity automatically anymore. To adapt to this change, the NLL estimator now gets another required argument, a phase space dataset. This is used to normalize the function.

Closes #191