### PR TITLE
test: check shape of kinematics dataset

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,12 +42,12 @@ def output_dir(pytestconfig) -> str:
 
 @pytest.fixture(scope="session")
 def helicity_model() -> AmplitudeModel:
-    return __create_model(formalism="canonical-helicity")
+    return __create_model(formalism="helicity")
 
 
 @pytest.fixture(scope="session")
 def canonical_model() -> AmplitudeModel:
-    return __create_model(formalism="helicity")
+    return __create_model(formalism="canonical-helicity")
 
 
 @pytest.fixture(scope="session")

--- a/tests/optimizer/test_callbacks.py
+++ b/tests/optimizer/test_callbacks.py
@@ -20,4 +20,5 @@ def test_load_latest_parameters(
 ):
     expected = fit_result["parameter_values"]
     imported = callback_type.load_latest_parameters(output_dir + filename)
-    assert pytest.approx(expected, rel=1e-2) == imported
+    for par in expected:
+        assert pytest.approx(expected[par], rel=1e-2) == imported[par]

--- a/tests/physics/helicity_formalism/test_kinematics.py
+++ b/tests/physics/helicity_formalism/test_kinematics.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-self-use
 
 import numpy as np
+import pandas as pd
 from expertsystem.amplitude.model import AmplitudeModel
 
 
@@ -35,3 +36,7 @@ class TestHelicityKinematics:
                 assert value == float_only_variables[var_name]
             else:
                 assert len(value) == sample_size
+
+    def test_convert_to_pandas(self, data_set: dict):
+        data_frame = pd.DataFrame(data_set)
+        assert set(data_frame.columns) == set(data_frame)

--- a/tests/physics/helicity_formalism/test_kinematics.py
+++ b/tests/physics/helicity_formalism/test_kinematics.py
@@ -1,0 +1,22 @@
+# pylint: disable=no-self-use
+
+import numpy as np
+
+
+class TestHelicityKinematics:
+    def test_convert(self, data_sample: np.ndarray, data_set: dict):
+        assert set(data_set) == {
+            "mSq_2",
+            "mSq_2+3+4",
+            "mSq_3",
+            "mSq_3+4",
+            "mSq_4",
+            "phi_3+4_2",
+            "phi_3_4_vs_2",
+            "theta_3+4_2",
+            "theta_3_4_vs_2",
+        }
+        _, sample_size, _ = data_sample.shape
+        assert sample_size == 10000
+        for array in data_set.values():
+            assert len(array) == sample_size

--- a/tests/physics/helicity_formalism/test_kinematics.py
+++ b/tests/physics/helicity_formalism/test_kinematics.py
@@ -1,10 +1,16 @@
 # pylint: disable=no-self-use
 
 import numpy as np
+from expertsystem.amplitude.model import AmplitudeModel
 
 
 class TestHelicityKinematics:
-    def test_convert(self, data_sample: np.ndarray, data_set: dict):
+    def test_convert(
+        self,
+        helicity_model: AmplitudeModel,
+        data_sample: np.ndarray,
+        data_set: dict,
+    ):
         assert set(data_set) == {
             "mSq_2",
             "mSq_2+3+4",
@@ -18,12 +24,14 @@ class TestHelicityKinematics:
         }
         _, sample_size, _ = data_sample.shape
         assert sample_size == 10000
+        final_state = helicity_model.kinematics.final_state
         float_only_variables = {
-            "mSq_2",
-            "mSq_3",
-            "mSq_4",
+            "mSq_2": final_state[2].mass ** 2,
+            "mSq_3": final_state[3].mass ** 2,
+            "mSq_4": final_state[4].mass ** 2,
         }
-        for var_name, array in data_set.items():
+        for var_name, value in data_set.items():
             if var_name in float_only_variables:
-                continue
-            assert len(array) == sample_size
+                assert value == float_only_variables[var_name]
+            else:
+                assert len(value) == sample_size

--- a/tests/physics/helicity_formalism/test_kinematics.py
+++ b/tests/physics/helicity_formalism/test_kinematics.py
@@ -18,5 +18,12 @@ class TestHelicityKinematics:
         }
         _, sample_size, _ = data_sample.shape
         assert sample_size == 10000
-        for array in data_set.values():
+        float_only_variables = {
+            "mSq_2",
+            "mSq_3",
+            "mSq_4",
+        }
+        for var_name, array in data_set.items():
+            if var_name in float_only_variables:
+                continue
             assert len(array) == sample_size


### PR DESCRIPTION
The doc CI for #192 fails because the shape of the data set that is returned by `HelicityKinematics.convert` is incorrect: its values contain floats, and should all be lists. This PR adds a test that checks the shape.