### PR TITLE
ci: ignore changes to requirements.txt

### DIFF
--- a/.github/workflows/requirements-pr.yml
+++ b/.github/workflows/requirements-pr.yml
@@ -64,6 +64,7 @@ jobs:
     name: Push changes
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
+    continue-on-error: true
     needs:
       - upgrade
     steps:

--- a/.github/workflows/requirements-pr.yml
+++ b/.github/workflows/requirements-pr.yml
@@ -25,16 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch origin
-      - name: Check for modified dependencies
-        id: git-diff
+      - name: Show modified dependencies
         run:
           echo "::set-output name=dependency-changes::$(git diff
           origin/$GITHUB_BASE_REF --name-only -- reqs setup.cfg)"
-        # Also triggers on (unwanted) changes to requirements.txt files
-      - name: Show dependency changes changes
+      - name: Check for dependency changes changes
+        id: git-diff
         run:
-          git diff origin/$GITHUB_BASE_REF -- reqs/requirements*.in setup.cfg
-      - name: Abort if fork PR and dependency changes
+          echo "::set-output name=dependency-changes::$(git diff
+          origin/$GITHUB_BASE_REF -- reqs/requirements*.in setup.cfg)"
+      - name: Abort if fork PR and changes to requirements
         if:
           github.event.pull_request.head.repo.full_name != github.repository &&
           steps.git-diff.outputs.dependency-changes != ''

--- a/.github/workflows/requirements-pr.yml
+++ b/.github/workflows/requirements-pr.yml
@@ -55,6 +55,7 @@ jobs:
         if: steps.git-diff.outputs.dependency-changes != ''
         run: bash reqs/upgrade.sh
       - uses: actions/upload-artifact@v2
+        if: steps.git-diff.outputs.dependency-changes != ''
         with:
           name: ${{ matrix.python-version }}
           path: reqs/${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,9 @@ repos:
       - id: prettier
         language_version: 12.18.2 # prettier does not specify node correctly
 
+  # The following tools have to be install locally, because they can also be
+  # used by code editors (e.g. linting and format-on-save).
+
   - repo: local
     hooks:
       - id: black

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,9 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.wordWrap": "off"
   },
+  "[pip-requirements]": {
+    "editor.wordWrap": "off"
+  },
   "[python]": {
     "editor.codeActionsOnSave": {
       "source.organizeImports": true
@@ -33,6 +36,12 @@
   "editor.rulers": [80],
   "files.associations": {
     "*.inc": "restructuredtext"
+  },
+  "files.watcherExclude": {
+    "**/*_cache/**": true,
+    "**/.eggs/**": true,
+    "**/.git/**": true,
+    "**/.tox/**": true
   },
   "git.rebaseWhenSync": true,
   "githubPullRequests.telemetry.enabled": false,

--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -42,7 +42,7 @@ entrypoints==0.3
 execnet==1.7.1
 expertsystem==0.6.5
 filelock==3.0.12
-flake8-blind-except==0.1.1
+flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
@@ -86,7 +86,7 @@ jupyter-server==1.1.4
 jupyter-sphinx==0.3.2
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.1
-jupyterlab-server==2.0.0
+jupyterlab-server==2.1.0
 jupyterlab-widgets==1.0.0
 jupyterlab==3.0.1
 keras-preprocessing==1.1.2
@@ -180,7 +180,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.4.2
+sphinx==3.4.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -120,7 +120,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.4.2
+sphinx==3.4.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3

--- a/reqs/3.6/requirements-sty.txt
+++ b/reqs/3.6/requirements-sty.txt
@@ -29,7 +29,7 @@ docutils==0.16
 execnet==1.7.1
 expertsystem==0.6.5
 filelock==3.0.12
-flake8-blind-except==0.1.1
+flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -40,7 +40,7 @@ entrypoints==0.3
 execnet==1.7.1
 expertsystem==0.6.5
 filelock==3.0.12
-flake8-blind-except==0.1.1
+flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
@@ -82,7 +82,7 @@ jupyter-server==1.1.4
 jupyter-sphinx==0.3.2
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.1
-jupyterlab-server==2.0.0
+jupyterlab-server==2.1.0
 jupyterlab-widgets==1.0.0
 jupyterlab==3.0.1
 keras-preprocessing==1.1.2
@@ -176,7 +176,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.4.2
+sphinx==3.4.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -119,7 +119,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.4.2
+sphinx==3.4.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3

--- a/reqs/3.7/requirements-sty.txt
+++ b/reqs/3.7/requirements-sty.txt
@@ -28,7 +28,7 @@ docutils==0.16
 execnet==1.7.1
 expertsystem==0.6.5
 filelock==3.0.12
-flake8-blind-except==0.1.1
+flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -40,7 +40,7 @@ entrypoints==0.3
 execnet==1.7.1
 expertsystem==0.6.5
 filelock==3.0.12
-flake8-blind-except==0.1.1
+flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
@@ -82,7 +82,7 @@ jupyter-server==1.1.4
 jupyter-sphinx==0.3.2
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.1
-jupyterlab-server==2.0.0
+jupyterlab-server==2.1.0
 jupyterlab-widgets==1.0.0
 jupyterlab==3.0.1
 keras-preprocessing==1.1.2
@@ -176,7 +176,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.4.2
+sphinx==3.4.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -119,7 +119,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.4.2
+sphinx==3.4.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3

--- a/reqs/3.8/requirements-sty.txt
+++ b/reqs/3.8/requirements-sty.txt
@@ -28,7 +28,7 @@ docutils==0.16
 execnet==1.7.1
 expertsystem==0.6.5
 filelock==3.0.12
-flake8-blind-except==0.1.1
+flake8-blind-except==0.2.0
 flake8-bugbear==20.11.1
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2


### PR DESCRIPTION
Previously, changes to the requirements.txt (so the pinned dependencies) would trigger the upgrade requirements job as well. This job can only run on PRs from branches on the same repository. Therefore it is not possible to cherry-pick upgrade commits and add them to a fork PR (see [failing upgrade CI](https://github.com/ComPWA/tensorwaves/runs/1667713835) for da0dd7b).