### PR TITLE
ci: add GitHub Actions workflow dispatch

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -12,6 +12,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  workflow_dispatch:
 
 jobs:
   check_links:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   update_release_draft:

--- a/.github/workflows/requirements-cron.yml
+++ b/.github/workflows/requirements-cron.yml
@@ -5,6 +5,7 @@ name: Requirements (scheduled)
 on:
   schedule:
     - cron: "0 2 * * 1"
+  workflow_dispatch:
 
 jobs:
   upgrade:


### PR DESCRIPTION
See #205 #206 #207
While [dependabot](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates) is good at spotting security problems, it cannot (yet) upgrade our `pip` dependencies as granularly as the [requirements cron job](https://github.com/ComPWA/tensorwaves/actions?query=workflow%3A%22Requirements+%28scheduled%29%22) can do (namely through `pip-compile`). This adds the possibility of triggering the upgrade job manually.