### PR TITLE
docs: switch to intersphinx links

### DIFF
--- a/docs/usage/1_create_model.ipynb
+++ b/docs/usage/1_create_model.ipynb
@@ -11,9 +11,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[tensorwaves](tensorwaves) requires you to first formulate an amplitude model that you want to fit to your data set. The [expertsystem](expertsystem) helps you to construct such a model.\n",
+    "{mod}`tensorwaves` requires you to first formulate an amplitude model that you want to fit to your data set. The {mod}`expertsystem` helps you to construct such a model.\n",
     "\n",
-    "This notebook briefly illustrates how to create such an amplitude model with the [expertsystem](expertsystem) and how to write it to a recipe file that can be understood by [tensorwaves](tensorwaves). For more control, have a look at {doc}`the usage guides of the PWA Expert System <expertsystem:usage>`."
+    "This notebook briefly illustrates how to create such an amplitude model with the {mod}`expertsystem` and how to write it to a recipe file that can be understood by {mod}`tensorwaves`. For more control, have a look at {doc}`the usage guides of the PWA Expert System <expertsystem:usage>`."
    ]
   },
   {
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a small goodie, you can use [graphviz](https://pypi.org/project/graphviz) to {doc}`visualize the found graphs <expertsystem:usage/visualization>`:"
+    "As a small goodie, you can use [`graphviz`](https://pypi.org/project/graphviz) to {doc}`visualize the found graphs <expertsystem:usage/visualization>`:"
    ]
   },
   {
@@ -110,7 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we can write the [AmplitudeModel](expertsystem.amplitude.model.AmplitudeModel), using the [io.write](expertsystem.io.write) function:"
+    "Finally, we can write the {class}`~expertsystem.amplitude.model.AmplitudeModel`, using the {func}`~expertsystem.io.write` function:"
    ]
   },
   {
@@ -126,7 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cool, that's it! We now have a recipe for an amplitude model with which to [generate data](./2_generate_data) and [perform a fit](./3_perform_fit)! In the [next steps](./2_generate_data), we will use use this [AmplitudeModel](expertsystem.amplitude.model.AmplitudeModel) as a fit model template for [tensorwaves](tensorwaves)."
+    "Cool, that's it! We now have a recipe for an amplitude model with which to {doc}`generate data <2_generate_data>` and {doc}`perform a fit <3_perform_fit>`! In the next steps, we will use use this {class}`~expertsystem.amplitude.model.AmplitudeModel` as a fit model template for {mod}`tensorwaves`."
    ]
   }
  ],

--- a/docs/usage/2_generate_data.ipynb
+++ b/docs/usage/2_generate_data.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this section, we will use the [AmplitudeModel](expertsystem.amplitude.model.AmplitudeModel) that we created with the expert system in [the previous step](./1_create_model) to generate a data sample via hit & miss Monte Carlo. We do this with the [tensorwaves.data.generate](tensorwaves.data.generate) module.\n",
+    "In this section, we will use the {class}`~expertsystem.amplitude.model.AmplitudeModel` that we created with the expert system in {doc}`the previous step <1_create_model>` to generate a data sample via hit & miss Monte Carlo. We do this with the {mod}`.data.generate` module.\n",
     "\n",
     "First, we {func}`~.expertsystem.io.load` an {class}`~expertsystem.amplitude.model.AmplitudeModel` that was created in the previous step:"
    ]
@@ -38,7 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An [AmplitudeModel](expertsystem.amplitude.model.AmplitudeModel) defines the kinematics, the particles involved in the reaction, the dynamics used for the model on which to perform the eventual optimization, etc."
+    "An {class}`~expertsystem.amplitude.model.AmplitudeModel` defines the kinematics, the particles involved in the reaction, the dynamics used for the model on which to perform the eventual optimization, etc."
    ]
   },
   {
@@ -61,7 +61,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A [Kinematics](tensorwaves.interfaces.Kinematics) object defines the kinematics of the particle reaction we are studying. From the final state masses listed here, we can see we are dealing with the reaction $J/\\psi \\to \\gamma\\pi^0\\pi^0$."
+    "A {class}`.Kinematics` object defines the kinematics of the particle reaction we are studying. From the final state masses listed here, we can see we are dealing with the reaction $J/\\psi \\to \\gamma\\pi^0\\pi^0$."
    ]
   },
   {
@@ -75,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Kinematics](tensorwaves.interfaces.Kinematics) define the constraints of the phase space. As such, we have enough information to generate a **phase-space sample** for this particle reaction. We do this with the [generate_phsp](tensorwaves.data.generate.generate_phsp) function. By default, this function uses [TFPhaseSpaceGenerator](tensorwaves.data.tf_phasespace.TFPhaseSpaceGenerator) as a, well... phase-space generator (using tensorflow in the back-end) and generates random numbers with [TFUniformRealNumberGenerator](tensorwaves.data.tf_phasespace.TFUniformRealNumberGenerator). You can specify this with the arguments of [generate_phsp](tensorwaves.data.generate.generate_phsp) function."
+    "{class}`.Kinematics` define the constraints of the phase space. As such, we have enough information to generate a **phase-space sample** for this particle reaction. We do this with the {func}`.generate_phsp` function. By default, this function uses {class}`.TFPhaseSpaceGenerator` as a, well... phase-space generator (using tensorflow in the back-end) and generates random numbers with {class}`.TFUniformRealNumberGenerator`. You can specify this with the arguments of {func}`.generate_phsp` function."
    ]
   },
   {
@@ -110,9 +110,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "'Data samples' are more complicated than phase space samples in that they represent the intensity profile resulting from a reaction. You therefore need an [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) object (or, more generally, a [Function](tensorwaves.interfaces.Function) instance) and a phase space over which to generate that intensity distribution. We call such a data sample an **intensity-based sample**.\n",
+    "'Data samples' are more complicated than phase space samples in that they represent the intensity profile resulting from a reaction. You therefore need an {class}`.IntensityTF` object (or, more generally, a {class}`.Function` instance) and a phase space over which to generate that intensity distribution. We call such a data sample an **intensity-based sample**.\n",
     "\n",
-    "An intensity-based sample is generated with the function [generate_data](tensorwaves.data.generate.generate_data). Its usage is similar to [generate_phsp](tensorwaves.data.generate.generate_phsp), but now you have to give an [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) in addition to the [Kinematics](tensorwaves.interfaces.Kinematics) object. An [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) object can be created with the [IntensityBuilder](tensorwaves.physics.helicity_formalism.amplitude.IntensityBuilder) class:"
+    "An intensity-based sample is generated with the function {func}`.generate_data`. Its usage is similar to {func}`.generate_phsp`, but now you have to give an {class}`.IntensityTF` in addition to the {class}`.Kinematics` object. An {class}`.IntensityTF` object can be created with the {class}`.IntensityBuilder` class:"
    ]
   },
   {
@@ -157,9 +157,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now have a phase space sample and an intensity-based sample. Their data structure isn't the most informative though: it's just a collection of four-momentum tuples. However, we can use the [Kinematics](tensorwaves.interfaces.Kinematics) class to convert those four-momentum tuples to a data set of kinematic variables.\n",
+    "We now have a phase space sample and an intensity-based sample. Their data structure isn't the most informative though: it's just a collection of four-momentum tuples. However, we can use the {class}`.Kinematics` class to convert those four-momentum tuples to a data set of kinematic variables.\n",
     "\n",
-    "Now we can use the [Kinematics.convert](tensorwaves.interfaces.Kinematics.convert) method to convert the phase space and data samples of four-momentum tuples to kinematic variables."
+    "Now we can use the {meth}`.Kinematics.convert` method to convert the phase space and data samples of four-momentum tuples to kinematic variables."
    ]
   },
   {
@@ -177,7 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The data set is just a [dict](dict) of kinematic variables (keys are the names, values is a list of computed values for each event). The numbers you see here are final state IDs as defined in the [AmplitudeModel](expertsystem.amplitude.model.AmplitudeModel) member of the [AmplitudeModel](expertsystem.amplitude.model.AmplitudeModel):"
+    "The data set is just a {obj}`dict` of kinematic variables (keys are the names, values is a list of computed values for each event). The numbers you see here are final state IDs as defined in the {class}`~expertsystem.amplitude.model.AmplitudeModel` member of the {class}`~expertsystem.amplitude.model.AmplitudeModel`:"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The data set is [dict](dict), which allows us to easily convert it to a [pandas.DataFrame](pandas.DataFrame) and plot its content in the form of a histogram:"
+    "The data set is {obj}`dict`, which allows us to easily convert it to a {class}`pandas.DataFrame` and plot its content in the form of a histogram:"
    ]
   },
   {
@@ -230,7 +230,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This also means that we can use all kinds of fancy plotting functionality of for instance [matplotlib.pyplot](matplotlib.pyplot) to see what's going on. Here's an example:"
+    "This also means that we can use all kinds of fancy plotting functionality of for instance {mod}`matplotlib.pyplot` to see what's going on. Here's an example:"
    ]
   },
   {
@@ -282,7 +282,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[tensorwaves](tensorwaves) currently has no export functionality for data samples. However, as we work with [numpy.ndarray](numpy.ndarray), it's easy to just ['pickle'](https://docs.python.org/3/library/pickle.html) these data samples with [numpy.save](numpy.save):"
+    "{mod}`tensorwaves` currently has no export functionality for data samples. However, as we work with {class}`numpy.ndarray`, it's easy to just {mod}`pickle` these data samples with {func}`numpy.save`:"
    ]
   },
   {
@@ -301,7 +301,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the [next step](./3_perform_fit), we will illustrate how to 'perform a fit' with [tensorwaves](tensorwaves) by optimizing the intensity model to these data samples."
+    "In the [next step](3_perform_fit), we will illustrate how to 'perform a fit' with {mod}`tensorwaves` by optimizing the intensity model to these data samples."
    ]
   }
  ],

--- a/docs/usage/3_perform_fit.ipynb
+++ b/docs/usage/3_perform_fit.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As explained in the [previous step](2_generate_data), an [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) object behaves just like a mathematical function that takes a set of data points as an argument and returns a list of intensities (real numbers). At this stage, we want to optimize the parameters of the intensity model, so that it matches the distribution of our data sample. This is what we call 'performing a fit'."
+    "As explained in the [previous step](2_generate_data), an {class}`.IntensityTF` object behaves just like a mathematical function that takes a set of data points as an argument and returns a list of intensities (real numbers). At this stage, we want to optimize the parameters of the intensity model, so that it matches the distribution of our data sample. This is what we call 'performing a fit'."
    ]
   },
   {
@@ -64,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To perform a fit, you need to define an **estimator**. An estimator is a measure for the discrepancy between the intensity model and the data distribution to which you fit. In PWA, we usually use an *unbinned negative log likelihood estimator*, which can be created as follows with the [tensorwaves.estimator](tensorwaves.estimator) module.\n",
+    "To perform a fit, you need to define an **estimator**. An estimator is a measure for the discrepancy between the intensity model and the data distribution to which you fit. In PWA, we usually use an *unbinned negative log likelihood estimator*, which can be created as follows with the {mod}`.estimator` module.\n",
     "\n",
     "Generally the intensity model is not normalized, but a log likelihood estimator requires a normalized function. This is where the phase space dataset comes into play! The intensity is separately evaluated with the phase space dataset and the normalization is achieved in this way. It is a required argument! Note that if you want to correct for the efficiency of the detector, a detector-reconstructed phase space dataset should be inserted here."
    ]
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The parameters that the [UnbinnedNLL](tensorwaves.estimator.UnbinnedNLL) carries, have been taken from the [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) object and you'll recognize them from the YAML recipe file that we created in [Step 1](1_create_model):"
+    "The parameters that the {class}`.UnbinnedNLL` carries, have been taken from the {class}`.IntensityTF` object and you'll recognize them from the YAML recipe file that we created in [Step 1](1_create_model):"
    ]
   },
   {
@@ -125,7 +125,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Starting the fit itself is quite simple: just create an optimizer instance of your choice, here [Minuit2](https://root.cern.ch/doc/master/Minuit2Page.html), and call its [optimize](tensorwaves.optimizer.minuit.Minuit2.optimize) method to start the fitting process. Notice that the [optimize](tensorwaves.optimizer.minuit.Minuit2.optimize) method requires a second argument. This is a mapping of parameter names that you want to fit to their initial values.\n",
+    "Starting the fit itself is quite simple: just create an optimizer instance of your choice, here [Minuit2](https://root.cern.ch/doc/master/Minuit2Page.html), and call its {meth}`~.Minuit2.optimize` method to start the fitting process. Notice that the {meth}`~.Minuit2.optimize` method requires a second argument. This is a mapping of parameter names that you want to fit to their initial values.\n",
     "\n",
     "Let's first select a few of the parameters that we saw in {ref}`Step 3.1 <usage/3_perform_fit:3.1 Define estimator>` and feed them to the optimizer to run the fit. Notice that we modify the parameters slightly to make the fit more interesting (we are running using a data sample that was generated with this very amplitude model after all)."
    ]
@@ -149,9 +149,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Recall that an [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) object is really just a [Function](tensorwaves.interfaces.Function) that computes the intensity for a certain dataset. This can be seen now nicely when we use these intensities as weights on the phase space sample and plot it together with the original dataset. Here, we look at the invariant mass distribution projection of the final states `3` and `4`, which, {ref}`as we saw before <usage/2_generate_data:2.4 Visualize kinematic variables>`, are the final state particles $\\pi^0,\\pi^0$.\n",
+    "Recall that an {class}`.IntensityTF` object is really just a {class}`.Function` that computes the intensity for a certain dataset. This can be seen now nicely when we use these intensities as weights on the phase space sample and plot it together with the original dataset. Here, we look at the invariant mass distribution projection of the final states `3` and `4`, which, {ref}`as we saw before <usage/2_generate_data:2.4 Visualize kinematic variables>`, are the final state particles $\\pi^0,\\pi^0$.\n",
     "\n",
-    "Don't forget to use [update_parameters](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF.update_parameters) first!"
+    "Don't forget to use {meth}`~.IntensityTF.update_parameters` first!"
    ]
   },
   {
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we create an [Optimizer](tensorwaves.interfaces.Optimizer) to [optimize](tensorwaves.optimizer.minuit.Minuit2.optimize) the model (which is embedded in the [Estimator](tensorwaves.interfaces.Estimator). Only the parameters that are given to the [optimize](tensorwaves.optimizer.minuit.Minuit2.optimize) method are optimized.\n",
+    "Finally, we create an {class}`.Optimizer` to {meth}`~.Minuit2.optimize` the model (which is embedded in the {class}`.Estimator`. Only the parameters that are given to the {meth}`~.Minuit2.optimize` method are optimized.\n",
     "\n",
     "Here, we choose to use {class}`.Minuit2`, which is the most common optimizer choice in high-energy physics. Notice that the {class}`.Minuit2` class allows one to list {mod}`~tensorwaves.optimizer.callbacks`. These are called during the {meth}`~.Optimizer.optimize` method. Here, we use {class}`.CallbackList` to 'stack' several callbacks together."
    ]
@@ -340,7 +340,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the same method as above, we renew the parameters of the [IntensityTF](tensorwaves.physics.helicity_formalism.amplitude.IntensityTF) and plot it again over the data distribution."
+    "Using the same method as above, we renew the parameters of the {class}`.IntensityTF` and plot it again over the data distribution."
    ]
   },
   {


### PR DESCRIPTION
_Spin-off from #203_

This makes the notebooks a bit easier to maintain (especially when there are interface changes) and results in nicer formatting:
![image](https://user-images.githubusercontent.com/29308176/108206316-8b052c00-7126-11eb-8a53-aa7a5424fde9.png)

where for instance `optimize()` is generated with `` {meth}`.Minuit2.optimize` ``.

The drawback is that the notebooks don't look as nice anymore:
![image](https://user-images.githubusercontent.com/29308176/108206522-c99ae680-7126-11eb-8d58-e8f1787f9f2c.png)
