### PR TITLE
ci: allow running notebooks through tox doclive

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,12 +43,19 @@ description =
 allowlist_externals =
     sphinx-autobuild
 passenv =
+    EXECUTE_NB
     TERM
 commands =
     sphinx-autobuild \
         --watch docs \
         --watch src \
+        --re-ignore .*/.ipynb_checkpoints/.* \
+        --re-ignore .*/__pycache__/.* \
+        --re-ignore docs/.*\.csv \
         --re-ignore docs/.*\.inv \
+        --re-ignore docs/.*\.picle \
+        --re-ignore docs/.*\.yaml \
+        --re-ignore docs/.*\.yml \
         --re-ignore docs/_build/.* \
         --re-ignore docs/api/.* \
         --open-browser \

--- a/tox.ini
+++ b/tox.ini
@@ -145,6 +145,7 @@ ignore = # more info: https://www.flake8rules.com/
     W503 # https://github.com/psf/black#line-breaks--binary-operators
 rst-roles =
     attr,
+    cite,
     class,
     doc,
     download,
@@ -157,6 +158,8 @@ rst-directives =
     deprecated,
     envvar,
     exception,
+    glue:figure,
+    glue:math,
     seealso,
 
 [pydocstyle]

--- a/tox.ini
+++ b/tox.ini
@@ -52,8 +52,10 @@ commands =
         --re-ignore .*/.ipynb_checkpoints/.* \
         --re-ignore .*/__pycache__/.* \
         --re-ignore docs/.*\.csv \
+        --re-ignore docs/.*\.gv \
         --re-ignore docs/.*\.inv \
-        --re-ignore docs/.*\.picle \
+        --re-ignore docs/.*\.json \
+        --re-ignore docs/.*\.pickle \
         --re-ignore docs/.*\.yaml \
         --re-ignore docs/.*\.yml \
         --re-ignore docs/_build/.* \


### PR DESCRIPTION
_Extracted from #222_

This PR makes it possible to run notebooks through
```
EXECUTE_NB= tox -e doclive
```
so that you can work on the notebooks and directly see how their output is rendered on RTD. Some additional `--re-ignore` have been added, so that `sphinx-autobuild` won't be retriggered once the notebooks have been run the first time.