### PR TITLE
docs: render figures as SVG

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -1,8 +1,27 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%config Completer.use_jedi = False\n",
+    "%config InlineBackend.figure_formats = ['svg']"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Usage"
    ]

--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -1,6 +1,23 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%config Completer.use_jedi = False\n",
+    "%config InlineBackend.figure_formats = ['svg']"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/usage/step1.ipynb
+++ b/docs/usage/step1.ipynb
@@ -1,6 +1,23 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%config Completer.use_jedi = False\n",
+    "%config InlineBackend.figure_formats = ['svg']"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/usage/step2.ipynb
+++ b/docs/usage/step2.ipynb
@@ -13,7 +13,8 @@
    },
    "outputs": [],
    "source": [
-    "%config Completer.use_jedi = False"
+    "%config Completer.use_jedi = False\n",
+    "%config InlineBackend.figure_formats = ['svg']"
    ]
   },
   {

--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -1,6 +1,23 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%config Completer.use_jedi = False\n",
+    "%config InlineBackend.figure_formats = ['svg']"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -665,7 +665,7 @@
     ")\n",
     "fit_traceback.plot(\"function_call\", \"estimator_value\", ax=ax1)\n",
     "fit_traceback.plot(\"function_call\", sorted(initial_parameters), ax=ax2)\n",
-    "fig.suptitle(\"Minuit2 optimizer process\", fontsize=16)\n",
+    "fig.suptitle(\"SciPy optimizer process\", fontsize=16)\n",
     "ax1.set_title(\"Negative log likelihood\")\n",
     "ax2.set_title(\"Parameter values\")\n",
     "ax1.set_xlabel(\"function call\")\n",


### PR DESCRIPTION
Matplotlib and graphviz output is currently rendered as PNG, despite this:
https://github.com/ComPWA/tensorwaves/blob/7ad175fd0d7e486937f373255d3529fb374c69bd/docs/conf.py#L172-L184

Ideal would be to set `InlineBackend.figure_formats = ['svg']` by default through some IPython configuration, see e.g. https://stackoverflow.com/a/17582607/13219025 and https://ipython.readthedocs.io/en/stable/development/config.html, but I currently can't get these settings to affect Sphinx.