### PR TITLE
feat: support lambdify to tensorflow

### DIFF
--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -84,7 +84,7 @@ jupyter-client==6.1.12
 jupyter-console==6.3.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12
-jupyter-server==1.4.1
+jupyter-server==1.5.0
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.5
@@ -94,7 +94,7 @@ jupyterlab==3.0.12
 keras-preprocessing==1.1.2
 kiwisolver==1.3.1
 labels==20.1.0
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
 livereload==2.6.3
 llvmlite==0.36.0
 markdown-it-py==0.6.2
@@ -126,7 +126,7 @@ packaging==20.9
 pandas==1.1.5
 pandocfilters==1.4.3
 parso==0.8.1
-particle==0.14.0
+particle==0.14.1
 pathspec==0.8.1
 pep517==0.10.0
 pep8-naming==0.11.1

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -87,7 +87,7 @@ packaging==20.9
 pandas==1.1.5
 pandocfilters==1.4.3
 parso==0.8.1
-particle==0.14.0
+particle==0.14.1
 pexpect==4.8.0
 phasespace==1.2.0
 pickleshare==0.7.5

--- a/reqs/3.6/requirements-extras.txt
+++ b/reqs/3.6/requirements-extras.txt
@@ -37,7 +37,7 @@ numba==0.53.0
 numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
-particle==0.14.0
+particle==0.14.1
 phasespace==1.2.0
 protobuf==3.15.6
 pyasn1-modules==0.2.8

--- a/reqs/3.6/requirements-sty.txt
+++ b/reqs/3.6/requirements-sty.txt
@@ -54,7 +54,7 @@ jaxlib==0.1.64
 jsonschema==3.2.0
 jupyter-core==4.7.1
 keras-preprocessing==1.1.2
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
 llvmlite==0.36.0
 markdown==3.3.4
 mccabe==0.6.1
@@ -69,7 +69,7 @@ numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
 packaging==20.9
-particle==0.14.0
+particle==0.14.1
 pathspec==0.8.1
 pep8-naming==0.11.1
 phasespace==1.2.0

--- a/reqs/3.6/requirements-test.txt
+++ b/reqs/3.6/requirements-test.txt
@@ -43,7 +43,7 @@ numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
 packaging==20.9
-particle==0.14.0
+particle==0.14.1
 phasespace==1.2.0
 pluggy==0.13.1
 protobuf==3.15.6

--- a/reqs/3.6/requirements.txt
+++ b/reqs/3.6/requirements.txt
@@ -33,7 +33,7 @@ mpmath==1.2.1
 numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
-particle==0.14.0
+particle==0.14.1
 phasespace==1.2.0
 protobuf==3.15.6
 pyasn1-modules==0.2.8

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -80,7 +80,7 @@ jupyter-client==6.1.12
 jupyter-console==6.3.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12
-jupyter-server==1.4.1
+jupyter-server==1.5.0
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.5
@@ -90,7 +90,7 @@ jupyterlab==3.0.12
 keras-preprocessing==1.1.2
 kiwisolver==1.3.1
 labels==20.1.0
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
 livereload==2.6.3
 llvmlite==0.36.0
 markdown-it-py==0.6.2
@@ -122,7 +122,7 @@ packaging==20.9
 pandas==1.2.3
 pandocfilters==1.4.3
 parso==0.8.1
-particle==0.14.0
+particle==0.14.1
 pathspec==0.8.1
 pep517==0.10.0
 pep8-naming==0.11.1

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -86,7 +86,7 @@ packaging==20.9
 pandas==1.2.3
 pandocfilters==1.4.3
 parso==0.8.1
-particle==0.14.0
+particle==0.14.1
 pexpect==4.8.0
 phasespace==1.2.0
 pickleshare==0.7.5

--- a/reqs/3.7/requirements-extras.txt
+++ b/reqs/3.7/requirements-extras.txt
@@ -36,7 +36,7 @@ numba==0.53.0
 numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
-particle==0.14.0
+particle==0.14.1
 phasespace==1.2.0
 protobuf==3.15.6
 pyasn1-modules==0.2.8

--- a/reqs/3.7/requirements-sty.txt
+++ b/reqs/3.7/requirements-sty.txt
@@ -52,7 +52,7 @@ jaxlib==0.1.64
 jsonschema==3.2.0
 jupyter-core==4.7.1
 keras-preprocessing==1.1.2
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
 llvmlite==0.36.0
 markdown==3.3.4
 mccabe==0.6.1
@@ -67,7 +67,7 @@ numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
 packaging==20.9
-particle==0.14.0
+particle==0.14.1
 pathspec==0.8.1
 pep8-naming==0.11.1
 phasespace==1.2.0

--- a/reqs/3.7/requirements-test.txt
+++ b/reqs/3.7/requirements-test.txt
@@ -42,7 +42,7 @@ numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
 packaging==20.9
-particle==0.14.0
+particle==0.14.1
 phasespace==1.2.0
 pluggy==0.13.1
 protobuf==3.15.6

--- a/reqs/3.7/requirements.txt
+++ b/reqs/3.7/requirements.txt
@@ -32,7 +32,7 @@ mpmath==1.2.1
 numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
-particle==0.14.0
+particle==0.14.1
 phasespace==1.2.0
 protobuf==3.15.6
 pyasn1-modules==0.2.8

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -80,7 +80,7 @@ jupyter-client==6.1.12
 jupyter-console==6.3.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12
-jupyter-server==1.4.1
+jupyter-server==1.5.0
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.5
@@ -90,7 +90,7 @@ jupyterlab==3.0.12
 keras-preprocessing==1.1.2
 kiwisolver==1.3.1
 labels==20.1.0
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
 livereload==2.6.3
 llvmlite==0.36.0
 markdown-it-py==0.6.2
@@ -122,7 +122,7 @@ packaging==20.9
 pandas==1.2.3
 pandocfilters==1.4.3
 parso==0.8.1
-particle==0.14.0
+particle==0.14.1
 pathspec==0.8.1
 pep517==0.10.0
 pep8-naming==0.11.1

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -86,7 +86,7 @@ packaging==20.9
 pandas==1.2.3
 pandocfilters==1.4.3
 parso==0.8.1
-particle==0.14.0
+particle==0.14.1
 pexpect==4.8.0
 phasespace==1.2.0
 pickleshare==0.7.5

--- a/reqs/3.8/requirements-extras.txt
+++ b/reqs/3.8/requirements-extras.txt
@@ -35,7 +35,7 @@ numba==0.53.0
 numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
-particle==0.14.0
+particle==0.14.1
 phasespace==1.2.0
 protobuf==3.15.6
 pyasn1-modules==0.2.8

--- a/reqs/3.8/requirements-sty.txt
+++ b/reqs/3.8/requirements-sty.txt
@@ -51,7 +51,7 @@ jaxlib==0.1.64
 jsonschema==3.2.0
 jupyter-core==4.7.1
 keras-preprocessing==1.1.2
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
 llvmlite==0.36.0
 markdown==3.3.4
 mccabe==0.6.1
@@ -66,7 +66,7 @@ numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
 packaging==20.9
-particle==0.14.0
+particle==0.14.1
 pathspec==0.8.1
 pep8-naming==0.11.1
 phasespace==1.2.0

--- a/reqs/3.8/requirements-test.txt
+++ b/reqs/3.8/requirements-test.txt
@@ -41,7 +41,7 @@ numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
 packaging==20.9
-particle==0.14.0
+particle==0.14.1
 phasespace==1.2.0
 pluggy==0.13.1
 protobuf==3.15.6

--- a/reqs/3.8/requirements.txt
+++ b/reqs/3.8/requirements.txt
@@ -31,7 +31,7 @@ mpmath==1.2.1
 numpy==1.19.5
 oauthlib==3.1.0
 opt-einsum==3.3.0
-particle==0.14.0
+particle==0.14.1
 phasespace==1.2.0
 protobuf==3.15.6
 pyasn1-modules==0.2.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     phasespace >= 1.2.0
     PyYAML
     sympy
-    tensorflow >= 2.0
+    tensorflow >= 2.4  # tensorflow.experimental.numpy
     tqdm >= 4.24.0  # autonotebook
     typing-extensions; python_version < "3.8.0"
 packages = find:

--- a/src/tensorwaves/optimizer/minuit.py
+++ b/src/tensorwaves/optimizer/minuit.py
@@ -73,7 +73,7 @@ class Minuit2(Optimizer):
             update_parameters(pars)
             parameters = parameter_handler.unflatten(flattened_parameters)
             estimator_value = estimator(parameters)
-            progress_bar.set_postfix({"estimator": estimator_value})
+            progress_bar.set_postfix({"estimator": float(estimator_value)})
             progress_bar.update()
             logs = create_log(estimator_value, parameters)
             self.__callback.on_function_call_end(n_function_calls, logs)


### PR DESCRIPTION
Many thanks to @mayou36 for pointing out [`tf.experimental.numpy`](https://www.tensorflow.org/api_docs/python/tf/experimental/numpy)!

Note: TF is currently the slowest of the backends for both optimizing and data generation. Could be that #100 offers a way out here and/or that we have to make the lambdifying a bit smarter.