### PR TITLE
fix: improve output of YAMLSummary

### DIFF
--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -271,6 +271,9 @@ class YAMLSummary(Callback, Loadable):
         self.__stream = open(self.__filename, "w")
 
     def on_optimize_end(self, logs: Optional[Dict[str, Any]] = None) -> None:
+        if logs is None:
+            return
+        self.__dump_to_yaml(logs)
         self.__stream.close()
 
     def on_iteration_end(
@@ -285,6 +288,9 @@ class YAMLSummary(Callback, Loadable):
             return
         if function_call % self.__step_size != 0:
             return
+        self.__dump_to_yaml(logs)
+
+    def __dump_to_yaml(self, logs: Dict[str, Any]) -> None:
         _empty_file(self.__stream)
         cast_logs = dict(logs)
         cast_logs["parameters"] = {


### PR DESCRIPTION
Two fixes for the `YAMLSummary`:
- Scalar tensors are converted to built-in `complex` or `float`, so that they are rendered more nicely in the output of `YAMLSummary`.
- `YAMLSummary` now also dumps in `on_optimize_end()`, so that the `load_latest_parameters` indeed returns the latest parameters (see `test_callbacks.py`).

(Rebased on #251)