### PR TITLE
fix: load complex parameter values from CSV

### DIFF
--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -189,10 +189,23 @@ class CSVSummary(Callback, Loadable):
 
     @staticmethod
     def load_latest_parameters(filename: str) -> dict:
+        def cast_non_numeric(value: str) -> Union[complex, float, str]:
+            # https://docs.python.org/3/library/csv.html#csv.QUOTE_NONNUMERIC
+            # does not work well for complex numbers
+            try:
+                return complex(value)
+            except ValueError:
+                try:
+                    return float(value)
+                except ValueError:
+                    return value
+
         with open(filename, "r") as stream:
-            reader = csv.DictReader(stream, quoting=csv.QUOTE_NONNUMERIC)
+            reader = csv.DictReader(stream)
             last_line = list(reader)[-1]
-        return last_line
+        return {
+            name: cast_non_numeric(value) for name, value in last_line.items()
+        }
 
 
 class TFSummary(Callback):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,7 @@ def estimator(
         helicity_model,
         dict(data_set),
         dict(phsp_set),
+        backend="jax",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # pylint: disable=redefined-outer-name
 
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import expertsystem as es
 import pytest
@@ -133,8 +133,11 @@ def estimator(
 
 
 @pytest.fixture(scope="session")
-def free_parameters() -> Dict[str, float]:
+def free_parameters() -> Dict[str, Union[complex, float]]:
+    # pylint: disable=line-too-long
     return {
+        "C[J/\\psi(1S) \\to f_{0}(980)_{0} \\gamma_{+1};f_{0}(980) \\to \\pi^{0}_{0} \\pi^{0}_{0}]": 1.0
+        + 0.0j,
         "Gamma_f(0)(500)": 0.3,
         "m_f(0)(980)": 1,
     }


### PR DESCRIPTION
The `csv.DictReader` crashes when there are complex values (and using `QUOTE_NONNUMERIC`). This was not spotted, because the tests only work with float parameters. Now one additional (complex) parameter is set free and the bug has been fixed. To speed up the tests, the UnbinnedNLL fixture uses Jax now.