### PR TITLE
refactor: wrap fit result in class

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,6 +8,7 @@ good-names=
     i,
     j,
     k,
+    p,
     q,
     x,
 

--- a/cspell.json
+++ b/cspell.json
@@ -194,6 +194,7 @@
         "unflatten",
         "unflattened",
         "unnormalized",
+        "unsubscriptable",
         "vstack",
         "xlabel",
         "xlim",

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -346,7 +346,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "optimized_parameters = fit_result[\"parameter_values\"]\n",
+    "optimized_parameters = fit_result.parameter_values\n",
     "intensity.update_parameters(optimized_parameters)\n",
     "compare_model(\"m_12\", data_set, phsp_set, intensity)"
    ]

--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -764,7 +764,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "optimized_parameters = result[\"parameter_values\"]\n",
+    "optimized_parameters = result.parameter_values\n",
     "function_1d.update_parameters(optimized_parameters)"
    ]
   },
@@ -1002,7 +1002,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "optimized_parameters = result[\"parameter_values\"]\n",
+    "optimized_parameters = result.parameter_values\n",
     "function_2d.update_parameters(optimized_parameters)"
    ]
   },

--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -430,7 +430,7 @@
    },
    "outputs": [],
    "source": [
-    "optimized_parameters = fit_result[\"parameter_values\"]\n",
+    "optimized_parameters = fit_result.parameter_values\n",
     "for p in optimized_parameters:\n",
     "    print(p)\n",
     "    print(f\"  initial:   {initial_parameters[p]:.3}\")\n",

--- a/src/tensorwaves/interfaces.py
+++ b/src/tensorwaves/interfaces.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from typing import (
+    Any,
     Callable,
     Dict,
     FrozenSet,
@@ -132,6 +133,8 @@ class FitResult:  # pylint: disable=too-many-instance-attributes
     parameter_values: Dict[str, ParameterValue]
     parameter_errors: Optional[Dict[str, ParameterValue]] = None
     iterations: Optional[int] = None
+    specifics: Optional[Any] = None
+    """Any additional info provided by the specific optimizer."""
 
 
 class Optimizer(ABC):

--- a/src/tensorwaves/optimizer/minuit.py
+++ b/src/tensorwaves/optimizer/minuit.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Iterable, Mapping, Optional, Union
 from iminuit import Minuit
 from tqdm.auto import tqdm
 
-from tensorwaves.interfaces import Estimator, Optimizer
+from tensorwaves.interfaces import Estimator, FitResult, Optimizer
 
 from ._parameter import ParameterFlattener
 from .callbacks import Callback, CallbackList
@@ -37,7 +37,7 @@ class Minuit2(Optimizer):
         self,
         estimator: Estimator,
         initial_parameters: Mapping[str, Union[complex, float]],
-    ) -> Dict[str, Any]:
+    ) -> FitResult:
         parameter_handler = ParameterFlattener(initial_parameters)
         flattened_parameters = parameter_handler.flatten(initial_parameters)
 
@@ -119,11 +119,11 @@ class Minuit2(Optimizer):
             )
         )
 
-        return {
-            "minimum_valid": minuit.valid,
-            "parameter_values": parameter_values,
-            "parameter_errors": parameter_errors,
-            "log_likelihood": minuit.fmin.fval,
-            "function_calls": minuit.fmin.nfcn,
-            "execution_time": end_time - start_time,
-        }
+        return FitResult(
+            minimum_valid=minuit.valid,
+            execution_time=end_time - start_time,
+            function_calls=minuit.fmin.nfcn,
+            estimator_value=minuit.fmin.fval,
+            parameter_values=parameter_values,
+            parameter_errors=parameter_errors,
+        )

--- a/src/tensorwaves/optimizer/minuit.py
+++ b/src/tensorwaves/optimizer/minuit.py
@@ -126,4 +126,5 @@ class Minuit2(Optimizer):
             estimator_value=minuit.fmin.fval,
             parameter_values=parameter_values,
             parameter_errors=parameter_errors,
+            specifics=minuit,
         )

--- a/src/tensorwaves/optimizer/scipy.py
+++ b/src/tensorwaves/optimizer/scipy.py
@@ -144,4 +144,5 @@ class ScipyMinimizer(Optimizer):
             estimator_value=result.fun,
             parameter_values=create_parameter_dict(result.x),
             iterations=result.nit,
+            specifics=result,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # pylint: disable=redefined-outer-name
 
-from typing import Any, Dict, Union
+from typing import Dict
 
 import expertsystem as es
 import pytest
@@ -16,7 +16,12 @@ from tensorwaves.data import generate_data, generate_phsp
 from tensorwaves.data.phasespace import TFUniformRealNumberGenerator
 from tensorwaves.data.transform import HelicityTransformer
 from tensorwaves.estimator import UnbinnedNLL
-from tensorwaves.interfaces import DataSample, DataTransformer
+from tensorwaves.interfaces import (
+    DataSample,
+    DataTransformer,
+    FitResult,
+    ParameterValue,
+)
 from tensorwaves.model import LambdifiedFunction, SympyModel
 from tensorwaves.optimizer.callbacks import (
     CallbackList,
@@ -133,7 +138,7 @@ def estimator(
 
 
 @pytest.fixture(scope="session")
-def free_parameters() -> Dict[str, Union[complex, float]]:
+def free_parameters() -> Dict[str, ParameterValue]:
     # pylint: disable=line-too-long
     return {
         "C[J/\\psi(1S) \\to f_{0}(980)_{0} \\gamma_{+1};f_{0}(980) \\to \\pi^{0}_{0} \\pi^{0}_{0}]": 1.0
@@ -148,7 +153,7 @@ def fit_result(
     estimator: UnbinnedNLL,
     free_parameters: Dict[str, float],
     output_dir: str,
-) -> Dict[str, Any]:
+) -> FitResult:
     optimizer = Minuit2(
         callback=CallbackList(
             [

--- a/tests/optimizer/test_callbacks.py
+++ b/tests/optimizer/test_callbacks.py
@@ -2,6 +2,7 @@ from typing import Type
 
 import pytest
 
+from tensorwaves.interfaces import FitResult
 from tensorwaves.optimizer.callbacks import CSVSummary, Loadable, YAMLSummary
 
 
@@ -16,9 +17,9 @@ def test_load_latest_parameters(
     callback_type: Type[Loadable],
     filename: str,
     output_dir: str,
-    fit_result: dict,
+    fit_result: FitResult,
 ):
-    expected = fit_result["parameter_values"]
+    expected = fit_result.parameter_values
     imported = callback_type.load_latest_parameters(output_dir + filename)
     for par in expected:
         assert pytest.approx(expected[par], rel=1e-2) == imported[par]

--- a/tests/optimizer/test_minuit.py
+++ b/tests/optimizer/test_minuit.py
@@ -1,3 +1,4 @@
+# pylint: disable=unsubscriptable-object
 from typing import Callable, Dict, Mapping, Optional, Union
 
 import pytest
@@ -89,8 +90,9 @@ def test_minuit2(
     minuit2 = Minuit2()
     result = minuit2.optimize(estimator, initial_params)
 
-    par_values = result["parameter_values"]
-    par_errors = result["parameter_errors"]
+    par_values = result.parameter_values
+    par_errors = result.parameter_errors
+    assert par_errors is not None
 
     if expected_result:
         for par_name, value in expected_result.items():
@@ -98,7 +100,7 @@ def test_minuit2(
                 par_values[par_name], abs=3 * par_errors[par_name]
             )
     else:
-        assert result["minimum_valid"] is False
+        assert result.minimum_valid is False
 
 
 def test_callback(mocker: MockerFixture) -> None:

--- a/tests/optimizer/test_scipy.py
+++ b/tests/optimizer/test_scipy.py
@@ -91,16 +91,15 @@ def test_scipy_optimize(
     scipy_optimizer = ScipyMinimizer()
     result = scipy_optimizer.optimize(estimator, initial_params)
 
-    par_values = result["parameter_values"]
-
+    par_values = result.parameter_values
     if expected_result:
-        assert result["minimum_valid"] is True
+        assert result.minimum_valid is True
         for par_name, value in expected_result.items():
             assert value == pytest.approx(
                 par_values[par_name], rel=1e-2, abs=1e-8
             )
     else:
-        assert result["minimum_valid"] is False
+        assert result.minimum_valid is False
 
 
 def test_callback(mocker: MockerFixture) -> None:

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name, redefined-outer-name
+# pylint: disable=invalid-name, redefined-outer-name, unsubscriptable-object
 
 import math
 from typing import Dict, Union
@@ -163,12 +163,13 @@ def test_sympy_unbinned_nll(
         initial_parameters=true_params,
     )
 
-    par_values = result["parameter_values"]
-    par_errors = result["parameter_errors"]
+    par_values = result.parameter_values
+    par_errors = result.parameter_errors
+    assert par_errors is not None
 
     assert set(par_values) == set(true_params)
     for par_name, par_value in true_params.items():
-        assert (
-            abs(par_values[par_name] - par_value) < 4.0 * par_errors[par_name]
-        )
+        par_error = par_errors[par_name]
+        assert isinstance(par_error, float)
+        assert abs(par_values[par_name] - par_value) < 4.0 * par_error
         assert par_value == pytest.approx(par_values[par_name], rel=0.1)


### PR DESCRIPTION
Wrapped the optimize `dict` output in a `FitResult` class. It's a rather simple `attr` data container that wraps what was previously in a `dict` form. Optimizer-specific info has been put under a `specifics` attribute.