### PR TITLE
feat: allow constructing Estimator from Function

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -318,7 +318,7 @@
    "outputs": [],
    "source": [
     "estimator = UnbinnedNLL(\n",
-    "    sympy_model,\n",
+    "    intensity,\n",
     "    data_set,\n",
     "    phsp_set,\n",
     "    backend=\"jax\",\n",

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -1,16 +1,25 @@
-# pylint: disable=invalid-name, redefined-outer-name, unsubscriptable-object
+# pylint: disable=invalid-name import-error redefined-outer-name unsubscriptable-object
 
 import math
 from typing import Dict, Union
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 import sympy as sp
+import tensorflow.experimental.numpy as tnp  # pyright: reportMissingImports=false
 
-from tensorwaves.estimator import UnbinnedNLL
+from tensorwaves.estimator import UnbinnedNLL, _find_function_in_backend
 from tensorwaves.interfaces import DataSample
 from tensorwaves.model import SympyModel
 from tensorwaves.optimizer.minuit import Minuit2
+
+
+def test_find_function_in_backend():
+    assert _find_function_in_backend("numpy", "mean") is np.mean
+    assert _find_function_in_backend("numpy", "log") is np.log
+    assert _find_function_in_backend("tf", "mean") is tnp.mean
+    assert _find_function_in_backend("jax", "mean") is jnp.mean
 
 
 def gaussian(mu_: float, sigma_: float) -> SympyModel:


### PR DESCRIPTION
If the amplitude model is complicated, it can take over an hour to lambdify it to a `Model`. So it's annoying to have to do that twice if  you use the same backend for data generation and fitting. This PR allows reusing a `LambdifiedFunction` for fitting.