### PR TITLE
feat: implement FitResult.count_number_of_parameters

### DIFF
--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -435,6 +435,44 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As an example, here is how to compute the [AIC](https://en.wikipedia.org/wiki/Akaike_information_criterion#Definition) and [BIC](https://en.wikipedia.org/wiki/Bayesian_information_criterion#Ddefinition) from this {obj}`.FitResult`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_real_par = fit_result.count_number_of_parameters(real=True)\n",
+    "n_events = len(list(data_set.values())[0])\n",
+    "log_likelihood = -fit_result.estimator_value\n",
+    "\n",
+    "bic = n_real_par * np.log(n_events) - 2 * log_likelihood\n",
+    "aic = 2 * n_real_par - 2 * log_likelihood"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(\"AIC:\", aic)\n",
+    "print(\"BIC:\", bic)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/src/tensorwaves/estimator.py
+++ b/src/tensorwaves/estimator.py
@@ -6,20 +6,24 @@ from typing import Callable, Dict, Mapping, Optional, Union
 
 import numpy as np
 
-from tensorwaves.interfaces import DataSample, Estimator, Function, Model
+from tensorwaves.interfaces import (
+    DataSample,
+    Estimator,
+    Function,
+    Model,
+    ParameterValue,
+)
 from tensorwaves.model import LambdifiedFunction, get_backend_modules
 
 
 def gradient_creator(
-    function: Callable[[Mapping[str, Union[float, complex]]], float],
+    function: Callable[[Mapping[str, ParameterValue]], float],
     backend: Union[str, tuple, dict],
-) -> Callable[
-    [Mapping[str, Union[float, complex]]], Dict[str, Union[float, complex]]
-]:
+) -> Callable[[Mapping[str, ParameterValue]], Dict[str, ParameterValue]]:
     # pylint: disable=import-outside-toplevel
     def not_implemented(
-        parameters: Mapping[str, Union[float, complex]]
-    ) -> Dict[str, Union[float, complex]]:
+        parameters: Mapping[str, ParameterValue]
+    ) -> Dict[str, ParameterValue]:
         raise NotImplementedError("Gradient not implemented.")
 
     if isinstance(backend, str) and backend == "jax":
@@ -55,7 +59,7 @@ class UnbinnedNLL(Estimator):  # pylint: disable=too-many-instance-attributes
         phsp_volume: float = 1.0,
         backend: Union[str, tuple, dict] = "numpy",
         use_caching: bool = False,
-        fixed_parameters: Optional[Dict[str, Union[float, complex]]] = None,
+        fixed_parameters: Optional[Dict[str, ParameterValue]] = None,
     ) -> None:
         self.__use_caching = use_caching
         self.__dataset = {k: np.array(v) for k, v in dataset.items()}
@@ -93,9 +97,7 @@ class UnbinnedNLL(Estimator):  # pylint: disable=too-many-instance-attributes
 
         self.__phsp_volume = phsp_volume
 
-    def __call__(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> float:
+    def __call__(self, parameters: Mapping[str, ParameterValue]) -> float:
         self.__data_function.update_parameters(parameters)
         if self.__use_caching:
             self.__phsp_function.update_parameters(parameters)
@@ -111,8 +113,8 @@ class UnbinnedNLL(Estimator):  # pylint: disable=too-many-instance-attributes
         return -self.__sum_function(self.__log_function(likelihoods))
 
     def gradient(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> Dict[str, Union[float, complex]]:
+        self, parameters: Mapping[str, ParameterValue]
+    ) -> Dict[str, ParameterValue]:
         return self.__gradient(parameters)
 
 

--- a/src/tensorwaves/interfaces.py
+++ b/src/tensorwaves/interfaces.py
@@ -180,7 +180,18 @@ class FitResult:  # pylint: disable=too-many-instance-attributes
                     if value != field.default:
                         p.breakable()
                         p.text(f"{field.name}=")
-                        p.pretty(value)
+                        if isinstance(value, dict):
+                            with p.group(indent=1, open="{"):
+                                for key, val in value.items():
+                                    p.breakable()
+                                    p.pretty(key)
+                                    p.text(": ")
+                                    p.pretty(val)
+                                    p.text(",")
+                            p.breakable()
+                            p.text("}")
+                        else:
+                            p.pretty(value)
                         p.text(",")
             p.breakable()
             p.text(")")

--- a/src/tensorwaves/interfaces.py
+++ b/src/tensorwaves/interfaces.py
@@ -154,6 +154,18 @@ class FitResult:  # pylint: disable=too-many-instance-attributes
     specifics: Optional[Any] = attr.ib(default=None)
     """Any additional info provided by the specific optimizer."""
 
+    @parameter_errors.validator  # pyright: reportOptionalMemberAccess=false
+    def _check_parameter_errors(
+        self, _: attr.Attribute, value: Optional[Dict[str, ParameterValue]]
+    ) -> None:
+        if value is None:
+            return
+        for par_name in value:
+            if par_name not in self.parameter_values:
+                raise ValueError(
+                    f'No parameter value exists for parameter error "{par_name}"'
+                )
+
     def _repr_pretty_(self, p: PrettyPrinter, cycle: bool) -> None:
         class_name = type(self).__name__
         if cycle:

--- a/src/tensorwaves/interfaces.py
+++ b/src/tensorwaves/interfaces.py
@@ -185,6 +185,25 @@ class FitResult:  # pylint: disable=too-many-instance-attributes
             p.breakable()
             p.text(")")
 
+    def count_number_of_parameters(self, real: bool = False) -> int:
+        """Compute the number of free parameters in a `.FitResult`.
+
+        Args:
+            fit_result (FitResult): Fit result from which to count it's
+                `~.FitResult.parameter_values`.
+
+
+            real (bool): Count complex valued parameters twice.
+        """
+        n_parameters = len(self.parameter_values)
+        if real:
+            complex_values = filter(
+                lambda v: isinstance(v, complex),
+                self.parameter_values.values(),
+            )
+            n_parameters += len(list(complex_values))
+        return n_parameters
+
 
 class Optimizer(ABC):
     """Optimize a fit model to a data set."""

--- a/src/tensorwaves/interfaces.py
+++ b/src/tensorwaves/interfaces.py
@@ -32,6 +32,7 @@ DataSample = Mapping[str, np.ndarray]
 """Input data for a `Function`."""
 
 ParameterValue = Union[complex, float]
+"""Allowed types for parameter values."""
 
 _PARAMETER_DICT_VALIDATOR = attr.validators.deep_mapping(
     key_validator=instance_of(str),

--- a/src/tensorwaves/model.py
+++ b/src/tensorwaves/model.py
@@ -28,7 +28,7 @@ from sympy.printing.numpy import (
 )
 from tqdm.auto import tqdm
 
-from tensorwaves.interfaces import DataSample, Function, Model
+from tensorwaves.interfaces import DataSample, Function, Model, ParameterValue
 
 _jax_known_functions = {
     k: v.replace("numpy.", "jnp.") for k, v in _numpy_known_functions.items()
@@ -290,11 +290,11 @@ class LambdifiedFunction(Function):
         )
 
     @property
-    def parameters(self) -> Dict[str, Union[float, complex]]:
+    def parameters(self) -> Dict[str, ParameterValue]:
         return self.__parameters
 
     def update_parameters(
-        self, new_parameters: Mapping[str, Union[float, complex]]
+        self, new_parameters: Mapping[str, ParameterValue]
     ) -> None:
         if not set(new_parameters) <= set(self.__parameters):
             over_defined = set(new_parameters) ^ set(self.__parameters)
@@ -314,7 +314,7 @@ class _ConstantSubExpressionSympyModel(Model):
     def __init__(
         self,
         expression: sp.Expr,
-        parameters: Dict[sp.Symbol, Union[float, complex]],
+        parameters: Dict[sp.Symbol, ParameterValue],
         fix_inputs: DataSample,
     ) -> None:
         self.__fix_inputs = fix_inputs
@@ -417,7 +417,7 @@ class _ConstantSubExpressionSympyModel(Model):
         return NotImplemented
 
     @property
-    def parameters(self) -> Dict[str, Union[float, complex]]:
+    def parameters(self) -> Dict[str, ParameterValue]:
         return {
             symbol.name: value
             for symbol, value in self.__not_fixed_parameters.items()
@@ -458,7 +458,7 @@ class SympyModel(Model):
     def __init__(
         self,
         expression: sp.Expr,
-        parameters: Dict[sp.Symbol, Union[float, complex]],
+        parameters: Dict[sp.Symbol, ParameterValue],
         max_complexity: Optional[int] = None,
     ) -> None:
         if not all(map(lambda p: isinstance(p, sp.Symbol), parameters)):
@@ -506,7 +506,7 @@ class SympyModel(Model):
         )
 
     @property
-    def parameters(self) -> Dict[str, Union[float, complex]]:
+    def parameters(self) -> Dict[str, ParameterValue]:
         return {
             symbol.name: value for symbol, value in self.__parameters.items()
         }

--- a/src/tensorwaves/optimizer/_parameter.py
+++ b/src/tensorwaves/optimizer/_parameter.py
@@ -1,10 +1,10 @@
-from typing import Dict, Mapping, Union
+from typing import Dict, Mapping
+
+from tensorwaves.interfaces import ParameterValue
 
 
 class ParameterFlattener:
-    def __init__(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> None:
+    def __init__(self, parameters: Mapping[str, ParameterValue]) -> None:
         self.__real_imag_to_complex_name = {}
         self.__complex_to_real_imag_name = {}
         for name, val in parameters.items():
@@ -17,8 +17,8 @@ class ParameterFlattener:
 
     def unflatten(
         self, flattened_parameters: Dict[str, float]
-    ) -> Dict[str, Union[float, complex]]:
-        parameters: Dict[str, Union[float, complex]] = {
+    ) -> Dict[str, ParameterValue]:
+        parameters: Dict[str, ParameterValue] = {
             k: v
             for k, v in flattened_parameters.items()
             if k not in self.__real_imag_to_complex_name
@@ -34,7 +34,7 @@ class ParameterFlattener:
         return parameters
 
     def flatten(
-        self, parameters: Mapping[str, Union[float, complex]]
+        self, parameters: Mapping[str, ParameterValue]
     ) -> Dict[str, float]:
         flattened_parameters = {}
         for par_name, value in parameters.items():

--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -11,6 +11,8 @@ import numpy as np
 import tensorflow as tf
 import yaml
 
+from tensorwaves.interfaces import ParameterValue
+
 
 class Loadable(ABC):
     @staticmethod
@@ -325,7 +327,7 @@ class YAMLSummary(Callback, Loadable):
         return fit_stats["parameters"]
 
 
-def _cast_value(value: Any) -> Union[complex, float]:
+def _cast_value(value: Any) -> ParameterValue:
     # cspell:ignore iscomplex
     if np.iscomplex(value) or isinstance(value, complex):
         return complex(value)

--- a/src/tensorwaves/optimizer/minuit.py
+++ b/src/tensorwaves/optimizer/minuit.py
@@ -5,12 +5,17 @@
 import logging
 import time
 from datetime import datetime
-from typing import Any, Dict, Iterable, Mapping, Optional, Union
+from typing import Any, Dict, Iterable, Mapping, Optional
 
 from iminuit import Minuit
 from tqdm.auto import tqdm
 
-from tensorwaves.interfaces import Estimator, FitResult, Optimizer
+from tensorwaves.interfaces import (
+    Estimator,
+    FitResult,
+    Optimizer,
+    ParameterValue,
+)
 
 from ._parameter import ParameterFlattener
 from .callbacks import Callback, CallbackList
@@ -36,7 +41,7 @@ class Minuit2(Optimizer):
     def optimize(  # pylint: disable=too-many-locals
         self,
         estimator: Estimator,
-        initial_parameters: Mapping[str, Union[complex, float]],
+        initial_parameters: Mapping[str, ParameterValue],
     ) -> FitResult:
         parameter_handler = ParameterFlattener(initial_parameters)
         flattened_parameters = parameter_handler.flatten(initial_parameters)

--- a/src/tensorwaves/optimizer/scipy.py
+++ b/src/tensorwaves/optimizer/scipy.py
@@ -4,12 +4,17 @@
 import logging
 import time
 from datetime import datetime
-from typing import Any, Dict, Iterable, Mapping, Optional, Union
+from typing import Any, Dict, Iterable, Mapping, Optional
 
 from scipy.optimize import minimize
 from tqdm.auto import tqdm
 
-from tensorwaves.interfaces import Estimator, FitResult, Optimizer
+from tensorwaves.interfaces import (
+    Estimator,
+    FitResult,
+    Optimizer,
+    ParameterValue,
+)
 
 from ._parameter import ParameterFlattener
 from .callbacks import Callback, CallbackList
@@ -39,7 +44,7 @@ class ScipyMinimizer(Optimizer):
     def optimize(  # pylint: disable=too-many-locals
         self,
         estimator: Estimator,
-        initial_parameters: Mapping[str, Union[complex, float]],
+        initial_parameters: Mapping[str, ParameterValue],
     ) -> FitResult:
         parameter_handler = ParameterFlattener(initial_parameters)
         flattened_parameters = parameter_handler.flatten(initial_parameters)
@@ -73,8 +78,8 @@ class ScipyMinimizer(Optimizer):
                 flattened_parameters[k] = pars[i]
 
         def create_parameter_dict(
-            pars: Iterable[Union[float]],
-        ) -> Dict[str, Union[float, complex]]:
+            pars: Iterable[float],
+        ) -> Dict[str, ParameterValue]:
             return parameter_handler.unflatten(
                 dict(zip(flattened_parameters.keys(), pars))
             )
@@ -98,7 +103,7 @@ class ScipyMinimizer(Optimizer):
             grad = estimator.gradient(parameters)
             return list(parameter_handler.flatten(grad).values())
 
-        def wrapped_callback(pars: Iterable[Union[float]]) -> None:
+        def wrapped_callback(pars: Iterable[float]) -> None:
             nonlocal iterations
             iterations += 1
             self.__callback.on_iteration_end(

--- a/tests/optimizer/test_minuit.py
+++ b/tests/optimizer/test_minuit.py
@@ -1,10 +1,10 @@
 # pylint: disable=unsubscriptable-object
-from typing import Callable, Dict, Mapping, Optional, Union
+from typing import Callable, Dict, Mapping, Optional
 
 import pytest
 from pytest_mock import MockerFixture
 
-from tensorwaves.interfaces import Estimator
+from tensorwaves.interfaces import Estimator, ParameterValue
 from tensorwaves.optimizer.minuit import Minuit2
 
 from . import CallbackMock, assert_invocations
@@ -14,15 +14,13 @@ class Polynomial1DMinimaEstimator(Estimator):
     def __init__(self, polynomial: Callable) -> None:
         self.__polynomial = polynomial
 
-    def __call__(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> float:
+    def __call__(self, parameters: Mapping[str, ParameterValue]) -> float:
         _x = parameters["x"]
         return self.__polynomial(_x)
 
     def gradient(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> Dict[str, Union[float, complex]]:
+        self, parameters: Mapping[str, ParameterValue]
+    ) -> Dict[str, ParameterValue]:
         return NotImplemented
 
 
@@ -30,16 +28,14 @@ class Polynomial2DMinimaEstimator(Estimator):
     def __init__(self, polynomial: Callable) -> None:
         self.__polynomial = polynomial
 
-    def __call__(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> float:
+    def __call__(self, parameters: Mapping[str, ParameterValue]) -> float:
         _x = parameters["x"]
         _y = parameters["y"]
         return self.__polynomial(_x, _y)
 
     def gradient(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> Dict[str, Union[float, complex]]:
+        self, parameters: Mapping[str, ParameterValue]
+    ) -> Dict[str, ParameterValue]:
         return NotImplemented
 
 

--- a/tests/optimizer/test_scipy.py
+++ b/tests/optimizer/test_scipy.py
@@ -1,9 +1,9 @@
-from typing import Callable, Dict, Mapping, Optional, Union
+from typing import Callable, Dict, Mapping, Optional
 
 import pytest
 from pytest_mock import MockerFixture
 
-from tensorwaves.interfaces import Estimator
+from tensorwaves.interfaces import Estimator, ParameterValue
 from tensorwaves.optimizer.scipy import ScipyMinimizer
 
 from . import CallbackMock, assert_invocations
@@ -13,15 +13,13 @@ class Polynomial1DMinimaEstimator(Estimator):
     def __init__(self, polynomial: Callable) -> None:
         self.__polynomial = polynomial
 
-    def __call__(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> float:
+    def __call__(self, parameters: Mapping[str, ParameterValue]) -> float:
         _x = parameters["x"]
         return self.__polynomial(_x)
 
     def gradient(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> Dict[str, Union[float, complex]]:
+        self, parameters: Mapping[str, ParameterValue]
+    ) -> Dict[str, ParameterValue]:
         return NotImplemented
 
 
@@ -29,16 +27,14 @@ class Polynomial2DMinimaEstimator(Estimator):
     def __init__(self, polynomial: Callable) -> None:
         self.__polynomial = polynomial
 
-    def __call__(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> float:
+    def __call__(self, parameters: Mapping[str, ParameterValue]) -> float:
         _x = parameters["x"]
         _y = parameters["y"]
         return self.__polynomial(_x, _y)
 
     def gradient(
-        self, parameters: Mapping[str, Union[float, complex]]
-    ) -> Dict[str, Union[float, complex]]:
+        self, parameters: Mapping[str, ParameterValue]
+    ) -> Dict[str, ParameterValue]:
         return NotImplemented
 
 

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -1,7 +1,7 @@
 # pylint: disable=invalid-name import-error redefined-outer-name unsubscriptable-object
 
 import math
-from typing import Dict, Union
+from typing import Dict
 
 import jax.numpy as jnp
 import numpy as np
@@ -10,7 +10,7 @@ import sympy as sp
 import tensorflow.experimental.numpy as tnp  # pyright: reportMissingImports=false
 
 from tensorwaves.estimator import UnbinnedNLL, _find_function_in_backend
-from tensorwaves.interfaces import DataSample
+from tensorwaves.interfaces import DataSample, ParameterValue
 from tensorwaves.model import SympyModel
 from tensorwaves.optimizer.minuit import Minuit2
 
@@ -157,7 +157,7 @@ __np_rng = np.random.default_rng(12345)
 def test_sympy_unbinned_nll(
     model: SympyModel,
     dataset: DataSample,
-    true_params: Dict[str, Union[complex, float]],
+    true_params: Dict[str, ParameterValue],
     phsp_dataset: DataSample,
 ):
     estimator = UnbinnedNLL(

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,0 +1,8 @@
+# pylint: disable=no-self-use
+from tensorwaves.interfaces import FitResult
+
+
+class TestFitResult:
+    def test_count_number_of_parameters(self, fit_result: FitResult):
+        assert fit_result.count_number_of_parameters(real=False) == 3
+        assert fit_result.count_number_of_parameters(real=True) == 4


### PR DESCRIPTION
Closes #290 

- Added a method `FitResult.count_number_of_parameters()`
- Constructor arguments of `FitResult` are now validated. This is to ensure that functions and methods like `count_number_of_parameters()` keep working.
- All parameters in `FitResult` are now 'pretty printed' below each other, e.g.:
  ```python
  FitResult(
   minimum_valid=True,
   execution_time=2.9841978549957275,
   function_calls=166,
   estimator_value=-7579.247627538372,
   parameter_values={
    'm_f(0)(980)': 0.989885368944097,
    'Gamma_f(0)(980)': 0.060228379644260165,
   },
   parameter_errors={
    'm_f(0)(980)': 0.0010628340144144574,
    'Gamma_f(0)(980)': 0.0016523232241513362,
   },
  )
  ```
- AIC and BIC example provided in documentation.
- Using type alias `ParameterValue` where possible instead of `Union[...]`.