### PR TITLE
refactor: rename real argument to complex_twice

### DIFF
--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -150,7 +150,7 @@
    },
    "outputs": [],
    "source": [
-    "x, mu, sigma = sp.symbols(\"x, mu, sigma\", real=True)\n",
+    "x, mu, sigma = sp.symbols(\"x, mu, sigma\", complex_twice=True)\n",
     "k = sp.Symbol(\"k\", integer=True)\n",
     "lam = sp.Symbol(\"lambda\", positive=True)\n",
     "style = \"<style>#output-body{display:flex; flex-direction: row;}</style>\"\n",
@@ -167,7 +167,7 @@
    "outputs": [],
    "source": [
     "x, a, b, c, mu1, mu2, sigma1, sigma2 = sp.symbols(\n",
-    "    \"x, (a:c), mu_(:2), sigma_(:2)\", real=True\n",
+    "    \"x, (a:c), mu_(:2), sigma_(:2)\", complex_twice=True\n",
     ")\n",
     "expression_1d = (\n",
     "    a * gaussian(x, mu1, sigma1)\n",
@@ -844,7 +844,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y, omega = sp.symbols(\"y, omega\", real=True)\n",
+    "y, omega = sp.symbols(\"y, omega\", complex_twice=True)\n",
     "expression_2d = expression_1d * sp.cos(y * omega) ** 2\n",
     "expression_2d"
    ]

--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -447,7 +447,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n_real_par = fit_result.count_number_of_parameters(real=True)\n",
+    "n_real_par = fit_result.count_number_of_parameters(complex_twice=True)\n",
     "n_events = len(list(data_set.values())[0])\n",
     "log_likelihood = -fit_result.estimator_value\n",
     "\n",

--- a/src/tensorwaves/interface.py
+++ b/src/tensorwaves/interface.py
@@ -198,7 +198,7 @@ class FitResult:  # pylint: disable=too-many-instance-attributes
             p.breakable()
             p.text(")")
 
-    def count_number_of_parameters(self, real: bool = False) -> int:
+    def count_number_of_parameters(self, complex_twice: bool = False) -> int:
         """Compute the number of free parameters in a `.FitResult`.
 
         Args:
@@ -206,10 +206,10 @@ class FitResult:  # pylint: disable=too-many-instance-attributes
                 `~.FitResult.parameter_values`.
 
 
-            real (bool): Count complex valued parameters twice.
+            complex_twice (bool): Count complex-valued parameters twice.
         """
         n_parameters = len(self.parameter_values)
-        if real:
+        if complex_twice:
             complex_values = filter(
                 lambda v: isinstance(v, complex),
                 self.parameter_values.values(),

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -4,5 +4,5 @@ from tensorwaves.interface import FitResult
 
 class TestFitResult:
     def test_count_number_of_parameters(self, fit_result: FitResult):
-        assert fit_result.count_number_of_parameters(real=False) == 3
-        assert fit_result.count_number_of_parameters(real=True) == 4
+        assert fit_result.count_number_of_parameters(complex_twice=False) == 3
+        assert fit_result.count_number_of_parameters(complex_twice=True) == 4

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,7 +10,7 @@ from tensorwaves.model import LambdifiedFunction, SympyModel
 @pytest.fixture(scope="module")
 def sympy_model() -> SympyModel:
     c_1, c_2, c_3, c_4 = sp.symbols("c_(1:5)")
-    x = sp.Symbol("x", real=True)
+    x = sp.Symbol("x", complex_twice=True)
     params = {
         c_1: 1 + 1j,
         c_2: -1 + 1j,


### PR DESCRIPTION
Fix-up to #291, e.g.:

```python
FitResult.count_number_of_parameter(complex_twice=True)
```

See discussion here
https://app.reviewnb.com/ComPWA/tensorwaves/blob/main/docs/usage/step3.ipynb/#comment-19307800