### PR TITLE
fix: add back metadata.kernelspec to notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.59
+    rev: 0.0.60
     hooks:
       - id: check-dev-files
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,13 +103,7 @@ repos:
             cell.metadata.code_folding
             metadata.celltoolbar
             metadata.interpreter
-            metadata.kernelspec
-            metadata.language_info.codemirror_mode
-            metadata.language_info.file_extension
-            metadata.language_info.mimetype
-            metadata.language_info.nbconvert_exporter
-            metadata.language_info.pygments_lexer
-            metadata.language_info.version
+            metadata.language_info
             metadata.notify_time
             metadata.toc
             metadata.varInspector
@@ -117,7 +111,6 @@ repos:
             metadata.toc-showcode
             metadata.toc-showmarkdowntxt
             metadata.toc-showtags
-
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.4.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,7 @@ repos:
             metadata.toc-showcode
             metadata.toc-showmarkdowntxt
             metadata.toc-showtags
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.4.1
     hooks:

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -521,8 +521,10 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/docs/usage/analytic-continuation.ipynb
+++ b/docs/usage/analytic-continuation.ipynb
@@ -265,8 +265,10 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -1080,8 +1080,10 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/docs/usage/faster-lambdify.ipynb
+++ b/docs/usage/faster-lambdify.ipynb
@@ -350,8 +350,10 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/docs/usage/step1.ipynb
+++ b/docs/usage/step1.ipynb
@@ -208,8 +208,10 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/docs/usage/step2.ipynb
+++ b/docs/usage/step2.ipynb
@@ -440,8 +440,10 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -1044,8 +1044,10 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Launch buttons are missing on the website since #337. This is because `metadata.kernelspec` was removed.