### PR TITLE
test: add unit tests for optimized_lambdify

### DIFF
--- a/docs/usage/faster-lambdify.ipynb
+++ b/docs/usage/faster-lambdify.ipynb
@@ -294,6 +294,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "lambdified_optimized"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "tags": []
    },
    "outputs": [],

--- a/docs/usage/faster-lambdify.ipynb
+++ b/docs/usage/faster-lambdify.ipynb
@@ -283,9 +283,10 @@
    "source": [
     "%%time\n",
     "lambdified_optimized = optimized_lambdify(\n",
-    "    sorted_symbols,\n",
     "    expression,\n",
+    "    symbols=sorted_symbols,\n",
     "    max_complexity=100,\n",
+    "    backend=\"numpy\",\n",
     ")"
    ]
   },

--- a/docs/usage/faster-lambdify.ipynb
+++ b/docs/usage/faster-lambdify.ipynb
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "x, y, z = sp.symbols(\"x:z\")\n",
-    "expr = x ** z + 2 * y + sp.log(y * z)\n",
+    "expr = x ** z + 2 * y\n",
     "expr"
    ]
   },
@@ -284,7 +284,7 @@
     "%%time\n",
     "lambdified_optimized = optimized_lambdify(\n",
     "    expression,\n",
-    "    symbols=sorted_symbols,\n",
+    "    sorted_symbols,\n",
     "    max_complexity=100,\n",
     "    backend=\"numpy\",\n",
     ")"
@@ -297,7 +297,9 @@
     "jupyter": {
      "source_hidden": true
     },
-    "tags": []
+    "tags": [
+     "remove-cell"
+    ]
    },
    "outputs": [],
    "source": [

--- a/src/tensorwaves/model/sympy.py
+++ b/src/tensorwaves/model/sympy.py
@@ -116,6 +116,9 @@ def optimized_lambdify(
         min_complexity=min_complexity,
         max_complexity=max_complexity,
     )
+    if not sub_expressions:
+        return _backend_lambdify(top_expression, symbols, backend, **kwargs)
+
     sorted_top_symbols = sorted(sub_expressions, key=lambda s: s.name)
     top_function = _backend_lambdify(
         top_expression, sorted_top_symbols, backend, **kwargs

--- a/tests/unit/model/test_sympy.py
+++ b/tests/unit/model/test_sympy.py
@@ -1,5 +1,7 @@
 # cspell:ignore lambdifygenerated
 # pylint: disable=invalid-name, no-self-use, redefined-outer-name
+import sys
+
 import numpy as np
 import pytest
 import sympy as sp
@@ -74,7 +76,10 @@ def test_optimized_lambdify(backend: str, max_complexity: int):
     else:
         repr_start = "<function _lambdifygenerated"
         if backend == "jax":
-            repr_start = "<CompiledFunction of " + repr_start
+            if sys.version_info >= (3, 7):
+                repr_start = "<CompiledFunction of " + repr_start
+            else:
+                repr_start = "<CompiledFunction object at 0x"
         assert func_repr.startswith(repr_start)
 
     data = (

--- a/tests/unit/model/test_sympy.py
+++ b/tests/unit/model/test_sympy.py
@@ -1,10 +1,11 @@
-# pylint: disable=no-self-use, redefined-outer-name
+# pylint: disable=invalid-name, no-self-use, redefined-outer-name
 import numpy as np
 import pytest
 import sympy as sp
 
 from tensorwaves.interface import DataSample, Function
 from tensorwaves.model import LambdifiedFunction, SympyModel
+from tensorwaves.model.sympy import split_expression
 
 
 class TestLambdifiedFunction:
@@ -48,3 +49,21 @@ class TestLambdifiedFunction:
         np.testing.assert_array_almost_equal(
             results, expected_results, decimal=4
         )
+
+
+def create_expression(x, y, z):
+    return x ** z + 2 * y
+
+
+def test_split_expression():
+    x, y, z = sp.symbols("x y z")
+    expression = create_expression(x, y, z)
+    top_expr, sub_expressions = split_expression(expression, max_complexity=3)
+    assert top_expr.free_symbols == set(sub_expressions)
+    assert expression == top_expr.xreplace(sub_expressions)
+
+    sub_symbols = sorted(top_expr.free_symbols, key=lambda s: s.name)
+    assert len(sub_symbols) == 2
+    f1, f2 = tuple(sub_symbols)
+    assert sub_expressions[f1] == x ** z
+    assert sub_expressions[f2] == 2 * y

--- a/tests/unit/model/test_sympy.py
+++ b/tests/unit/model/test_sympy.py
@@ -57,7 +57,7 @@ def create_expression(x, y, z):
 
 
 @pytest.mark.parametrize("backend", ["jax", "math", "numpy", "tf"])
-@pytest.mark.parametrize("max_complexity", [2, 3])
+@pytest.mark.parametrize("max_complexity", [2, 3, 4])
 def test_optimized_lambdify(backend: str, max_complexity: int):
     x, y, z = sp.symbols("x y z")
     expression = create_expression(x, y, z)
@@ -69,7 +69,13 @@ def test_optimized_lambdify(backend: str, max_complexity: int):
     )
 
     func_repr = str(function)
-    assert func_repr.startswith("<function optimized_lambdify.<locals>")
+    if max_complexity <= 3:
+        assert func_repr.startswith("<function optimized_lambdify.<locals>")
+    else:
+        repr_start = "<function _lambdifygenerated"
+        if backend == "jax":
+            repr_start = "<CompiledFunction of " + repr_start
+        assert func_repr.startswith(repr_start)
 
     data = (
         np.array([1, 2]),


### PR DESCRIPTION
Additional fixes:
- The faster-lambdify notebook was failing due to the interface change introduced by #348. This was not noticed, because the `%%time` statement in the cell makes the error code of that cell return 'success'. The error has been fixed and a hidden test cell has been added to prevent such failures in the future.
- `optimized_lambdify` now directly calls `_backend_lambdify` is `max_complexity` is higher than the number of nodes in the expression.