### PR TITLE
fix: write callback output to separate files

### DIFF
--- a/tests/integration/ampform/conftest.py
+++ b/tests/integration/ampform/conftest.py
@@ -172,17 +172,23 @@ def free_parameters(
 @pytest.fixture(scope="session")
 def fit_result(
     reaction: qrules.ReactionInfo,
+    sympy_model: SympyModel,
     estimator: UnbinnedNLL,
     free_parameters: Dict[str, float],
     output_dir: Path,
 ) -> FitResult:
-    formalism = reaction.formalism[:4]
+    formalism_alias = reaction.formalism[:4]
+    if sympy_model.max_complexity is None:
+        lambdify_type = "normal"
+    else:
+        lambdify_type = "optimized"
+    identifier = f"{formalism_alias}_{lambdify_type}"
     optimizer = Minuit2(
         callback=CallbackList(
             [
-                CSVSummary(output_dir / f"fit_traceback_{formalism}.csv"),
+                CSVSummary(output_dir / f"fit_traceback_{identifier}.csv"),
                 YAMLSummary(
-                    output_dir / f"fit_result_{formalism}.yml", step_size=1
+                    output_dir / f"fit_result_{identifier}.yml", step_size=1
                 ),
             ]
         )

--- a/tests/integration/ampform/test_callbacks.py
+++ b/tests/integration/ampform/test_callbacks.py
@@ -5,25 +5,31 @@ import pytest
 import qrules
 
 from tensorwaves.interface import FitResult
+from tensorwaves.model.sympy import SympyModel
 from tensorwaves.optimizer.callbacks import CSVSummary, Loadable, YAMLSummary
 
 
 @pytest.mark.parametrize(
     ("callback_type", "filename"),
     [
-        (CSVSummary, "fit_traceback_{}.csv"),
-        (YAMLSummary, "fit_result_{}.yml"),
+        (CSVSummary, "fit_traceback_{}_{}.csv"),
+        (YAMLSummary, "fit_result_{}_{}.yml"),
     ],
 )
 def test_load_latest_parameters(
     reaction: qrules.ReactionInfo,
+    sympy_model: SympyModel,
     callback_type: Type[Loadable],
     filename: str,
     output_dir: Path,
     fit_result: FitResult,
 ):
-    formalism = reaction.formalism[:4]
-    filename = filename.format(formalism)
+    formalism_alias = reaction.formalism[:4]
+    if sympy_model.max_complexity is None:
+        lambdify_type = "normal"
+    else:
+        lambdify_type = "optimized"
+    filename = filename.format(formalism_alias, lambdify_type)
     expected = fit_result.parameter_values
     imported = callback_type.load_latest_parameters(output_dir / filename)
     for par in expected:


### PR DESCRIPTION
Integration tests have become unstable since #349, see e.g. https://github.com/ComPWA/tensorwaves/actions/runs/1504632721, because the callback output is written to the same file when using `optimized_lambdify` / `_backend_lambdify`.