### PR TITLE
docs: add API links to FitResult.specifics

### DIFF
--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -473,6 +473,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Covariance matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each of the {mod}`.optimizer`s offer more specific information about the fit result. This information can be accessed with {attr}`.FitResult.specifics`. A common example would be to get the `~iminuit.Minuit.covariance` matrix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "covariance_matrix = fit_result.specifics.covariance\n",
+    "covariance_matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### AIC and BIC"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "As an example, here is how to compute the [AIC](https://en.wikipedia.org/wiki/Akaike_information_criterion#Definition) and [BIC](https://en.wikipedia.org/wiki/Bayesian_information_criterion#Ddefinition) from this {obj}`.FitResult`:"
    ]
   },

--- a/src/tensorwaves/interface.py
+++ b/src/tensorwaves/interface.py
@@ -156,6 +156,9 @@ class FitResult:  # pylint: disable=too-many-instance-attributes
 
     - `iminuit.Minuit`
     - `scipy.optimize.OptimizeResult`
+
+    This way, you can for instance get the `~iminuit.Minuit.covariance` matrix.
+    See also :ref:`usage/step3:Covariance matrix`.
     """
 
     @parameter_errors.validator  # pyright: reportOptionalMemberAccess=false

--- a/src/tensorwaves/interface.py
+++ b/src/tensorwaves/interface.py
@@ -149,7 +149,14 @@ class FitResult:  # pylint: disable=too-many-instance-attributes
         default=None, validator=optional(instance_of(int))
     )
     specifics: Optional[Any] = attr.ib(default=None)
-    """Any additional info provided by the specific optimizer."""
+    """Any additional info provided by the specific optimizer.
+
+    An instance returned by one of the implemented optimizers under the
+    :mod:`.optimizer` module. Currently one of:
+
+    - `iminuit.Minuit`
+    - `scipy.optimize.OptimizeResult`
+    """
 
     @parameter_errors.validator  # pyright: reportOptionalMemberAccess=false
     def _check_parameter_errors(


### PR DESCRIPTION
Added links to the 'fit result' objects in the `iminuit` and SciPy APIs.