### PR TITLE
ci: switch to nbmake

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -14,7 +14,7 @@ argon2-cffi==21.1.0
 astroid==2.7.3
 astunparse==1.6.3
 async-generator==1.10
-attrs==20.3.0
+attrs==21.2.0
 babel==2.9.1
 backcall==0.2.0
 backports.entry-points-selectable==1.1.1
@@ -97,6 +97,7 @@ jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
 jupyterlab==3.2.4
 jupyterlab-code-formatter==1.4.10
+jupyterlab-pygments==0.1.2
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
 keras==2.6.0
@@ -119,9 +120,10 @@ myst-nb==0.13.1
 myst-parser==0.15.2
 nbclassic==0.3.4
 nbclient==0.5.9
-nbconvert==5.6.1
+nbconvert==6.0.7
 nbdime==3.1.1
 nbformat==5.1.3
+nbmake==1.0
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 notebook==6.4.6
@@ -144,7 +146,7 @@ pillow==8.4.0
 pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
-pre-commit==2.15.0
+pre-commit==2.16.0
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 protobuf==3.19.1
@@ -154,6 +156,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.8.0
 pycparser==2.21
+pydantic==1.8.2
 pydata-sphinx-theme==0.7.2
 pydocstyle==6.1.1
 pyflakes==2.4.0
@@ -165,7 +168,6 @@ pytest==6.2.5
 pytest-cov==3.0.0
 pytest-forked==1.3.0
 pytest-mock==3.6.1
-pytest-notebook==0.6.1
 pytest-profiling==1.7.0
 pytest-xdist==2.4.0
 python-constraint==1.4.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -13,7 +13,7 @@ argcomplete==1.12.3
 argon2-cffi==21.1.0
 astroid==2.9.0
 astunparse==1.6.3
-attrs==20.3.0
+attrs==21.2.0
 babel==2.9.1
 backcall==0.2.0
 backports.entry-points-selectable==1.1.1
@@ -94,6 +94,7 @@ jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
 jupyterlab==3.2.4
 jupyterlab-code-formatter==1.4.10
+jupyterlab-pygments==0.1.2
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
 keras==2.7.0
@@ -118,9 +119,10 @@ myst-nb==0.13.1
 myst-parser==0.15.2
 nbclassic==0.3.4
 nbclient==0.5.9
-nbconvert==5.6.1
+nbconvert==6.3.0
 nbdime==3.1.1
 nbformat==5.1.3
+nbmake==1.0
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 notebook==6.4.6
@@ -143,7 +145,7 @@ pillow==8.4.0
 pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
-pre-commit==2.15.0
+pre-commit==2.16.0
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 protobuf==3.19.1
@@ -153,6 +155,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.8.0
 pycparser==2.21
+pydantic==1.8.2
 pydata-sphinx-theme==0.7.2
 pydocstyle==6.1.1
 pyflakes==2.4.0
@@ -164,7 +167,6 @@ pytest==6.2.5
 pytest-cov==3.0.0
 pytest-forked==1.3.0
 pytest-mock==3.6.1
-pytest-notebook==0.6.1
 pytest-profiling==1.7.0
 pytest-xdist==2.4.0
 python-constraint==1.4.0
@@ -226,7 +228,7 @@ types-pkg-resources==0.1.3
 types-pyyaml==6.0.1
 types-requests==2.26.1
 types-setuptools==57.4.4
-typing-extensions==4.0.0 ; python_version < "3.8.0"
+typing-extensions==4.0.1 ; python_version < "3.8.0"
 urllib3==1.26.7
 virtualenv==20.10.0
 wcwidth==0.2.5

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -12,7 +12,7 @@ aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==21.1.0
 astroid==2.9.0
 astunparse==1.6.3
-attrs==20.3.0
+attrs==21.2.0
 babel==2.9.1
 backcall==0.2.0
 backports.entry-points-selectable==1.1.1
@@ -93,6 +93,7 @@ jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
 jupyterlab==3.2.4
 jupyterlab-code-formatter==1.4.10
+jupyterlab-pygments==0.1.2
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
 keras==2.7.0
@@ -117,9 +118,10 @@ myst-nb==0.13.1
 myst-parser==0.15.2
 nbclassic==0.3.4
 nbclient==0.5.9
-nbconvert==5.6.1
+nbconvert==6.3.0
 nbdime==3.1.1
 nbformat==5.1.3
+nbmake==1.0
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 notebook==6.4.6
@@ -142,7 +144,7 @@ pillow==8.4.0
 pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
-pre-commit==2.15.0
+pre-commit==2.16.0
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 protobuf==3.19.1
@@ -152,6 +154,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.8.0
 pycparser==2.21
+pydantic==1.8.2
 pydata-sphinx-theme==0.7.2
 pydocstyle==6.1.1
 pyflakes==2.4.0
@@ -163,7 +166,6 @@ pytest==6.2.5
 pytest-cov==3.0.0
 pytest-forked==1.3.0
 pytest-mock==3.6.1
-pytest-notebook==0.6.1
 pytest-profiling==1.7.0
 pytest-xdist==2.4.0
 python-constraint==1.4.0
@@ -224,7 +226,7 @@ types-pkg-resources==0.1.3
 types-pyyaml==6.0.1
 types-requests==2.26.1
 types-setuptools==57.4.4
-typing-extensions==4.0.0
+typing-extensions==4.0.1
 urllib3==1.26.7
 virtualenv==20.10.0
 wcwidth==0.2.5

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -12,7 +12,7 @@ aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==21.1.0
 astroid==2.9.0
 astunparse==1.6.3
-attrs==20.3.0
+attrs==21.2.0
 babel==2.9.1
 backcall==0.2.0
 backports.entry-points-selectable==1.1.1
@@ -70,7 +70,6 @@ idna==3.3
 imagesize==1.3.0
 iminuit==2.8.4
 importlib-metadata==4.8.2
-importlib-resources==5.4.0
 iniconfig==1.1.1
 ipykernel==6.5.1
 ipython==7.30.0
@@ -93,6 +92,7 @@ jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
 jupyterlab==3.2.4
 jupyterlab-code-formatter==1.4.10
+jupyterlab-pygments==0.1.2
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
 keras==2.7.0
@@ -117,9 +117,10 @@ myst-nb==0.13.1
 myst-parser==0.15.2
 nbclassic==0.3.4
 nbclient==0.5.9
-nbconvert==5.6.1
+nbconvert==6.3.0
 nbdime==3.1.1
 nbformat==5.1.3
+nbmake==1.0
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 notebook==6.4.6
@@ -142,7 +143,7 @@ pillow==8.4.0
 pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
-pre-commit==2.15.0
+pre-commit==2.16.0
 prometheus-client==0.12.0
 prompt-toolkit==3.0.23
 protobuf==3.19.1
@@ -152,6 +153,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.8.0
 pycparser==2.21
+pydantic==1.8.2
 pydata-sphinx-theme==0.7.2
 pydocstyle==6.1.1
 pyflakes==2.4.0
@@ -163,7 +165,6 @@ pytest==6.2.5
 pytest-cov==3.0.0
 pytest-forked==1.3.0
 pytest-mock==3.6.1
-pytest-notebook==0.6.1
 pytest-profiling==1.7.0
 pytest-xdist==2.4.0
 python-constraint==1.4.0
@@ -224,7 +225,7 @@ types-pkg-resources==0.1.3
 types-pyyaml==6.0.1
 types-requests==2.26.1
 types-setuptools==57.4.4
-typing-extensions==4.0.0
+typing-extensions==4.0.1
 urllib3==1.26.7
 virtualenv==20.10.0
 wcwidth==0.2.5

--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -89,7 +89,6 @@
     "    expression=model.expression.doit(),\n",
     "    parameters=model.parameter_defaults,\n",
     "    backend=\"jax\",\n",
-    "    max_complexity=100,\n",
     ")"
    ]
   },

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,11 +14,7 @@ addopts =
 filterwarnings =
     ignore:.*Using or importing the ABCs.*:DeprecationWarning
     ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning
-nb_diff_ignore =
-    /cells/*/execution_count
-    /cells/*/outputs
-    /metadata/language_info/version
-    /metadata/widgets
+    ignore:Passing a schema to Validator.iter_errors is deprecated.*:DeprecationWarning
 norecursedirs =
     _build
 markers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,10 +86,10 @@ doc =
 test =
     %(all)s
     ipython  # test _repr_pretty_
+    nbmake
     pytest
     pytest-cov
     pytest-mock >=3.3.0
-    pytest-notebook
     pytest-profiling
     pytest-xdist
 format =

--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -21,7 +21,7 @@ class ParametrizedBackendFunction(ParametrizedFunction):
         parameters: Mapping[str, ParameterValue],
     ) -> None:
         self.__function = function
-        self.__argument_order = argument_order
+        self.__argument_order = tuple(argument_order)
         self.__parameters = dict(parameters)
 
     def __call__(self, dataset: DataSample) -> np.ndarray:

--- a/tox.ini
+++ b/tox.ini
@@ -137,4 +137,4 @@ description =
 allowlist_externals =
     pytest
 commands =
-    pytest {posargs:docs} --nb-test-files
+    pytest --nbmake {posargs:docs}


### PR DESCRIPTION
Switch from [`pytest-notebook`](https://pypi.org/project/pytest-notebook) to [`nbmake`](https://pypi.org/project/nbmake). Now it's again possible to run specific notebooks from the terminal with e.g.:

```shell
pytest --nbmake docs/usage/basics.ipynb
```

Other small fixes:
- Avoid `fast_lambdify()` in Jupyter notebooks to speed up docs workflow.
- Cast to `tuple` in `ParametrizedBackendFunction`.