### PR TITLE
fix: jit-compile recombined fast_lambdify function

### DIFF
--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "As explained in the {doc}`previous step <step2>`, a {class}`.ParametrizedFunction` can compute a list of intensities (real numbers) for an input {obj}`.DataSample`. At this stage, we want to optimize the parameters of this {class}`.ParametrizedFunction`, so that it matches the distribution of our data sample. This is what we call 'fitting'.\n",
     "\n",
-    "First, we load the relevant data from the previous steps."
+    "First, we load the relevant data from the previous steps. Notice that we use {func}`.create_parametrized_function` with the argument `max_complexity`, which speeds up lambdification (see {doc}`/usage/faster-lambdify`)."
    ]
   },
   {
@@ -89,6 +89,7 @@
     "    expression=model.expression.doit(),\n",
     "    parameters=model.parameter_defaults,\n",
     "    backend=\"jax\",\n",
+    "    max_complexity=100,\n",
     ")"
    ]
   },

--- a/src/tensorwaves/_backend.py
+++ b/src/tensorwaves/_backend.py
@@ -47,3 +47,19 @@ def get_backend_modules(
             return tnp.__dict__
 
     return backend
+
+
+def jit_compile(function: Callable, backend: str) -> Callable:
+    # pylint: disable=import-outside-toplevel
+    backend = backend.lower()
+    if backend == "jax":
+        import jax
+
+        return jax.jit(function)
+
+    if backend == "numba":
+        import numba
+
+        return numba.jit(function, forceobj=True, parallel=True)
+
+    raise NotImplementedError(f"Cannot JIT-compile with backend {backend}")

--- a/src/tensorwaves/_backend.py
+++ b/src/tensorwaves/_backend.py
@@ -1,5 +1,7 @@
 """Computational back-end handling."""
 
+
+from functools import partial
 from typing import Callable, Union
 
 
@@ -49,17 +51,17 @@ def get_backend_modules(
     return backend
 
 
-def jit_compile(function: Callable, backend: str) -> Callable:
+def jit_compile(backend: str) -> Callable:
     # pylint: disable=import-outside-toplevel
     backend = backend.lower()
     if backend == "jax":
         import jax
 
-        return jax.jit(function)
+        return jax.jit
 
     if backend == "numba":
         import numba
 
-        return numba.jit(function, forceobj=True, parallel=True)
+        return partial(numba.jit, forceobj=True, parallel=True)
 
-    raise NotImplementedError(f"Cannot JIT-compile with backend {backend}")
+    return lambda x: x

--- a/src/tensorwaves/function/sympy.py
+++ b/src/tensorwaves/function/sympy.py
@@ -21,7 +21,7 @@ from sympy.printing.numpy import (
 )
 from tqdm.auto import tqdm
 
-from tensorwaves._backend import get_backend_modules
+from tensorwaves._backend import get_backend_modules, jit_compile
 from tensorwaves.interface import ParameterValue
 
 from . import ParametrizedBackendFunction
@@ -181,28 +181,23 @@ def lambdify(
     **kwargs: Any,
 ) -> Callable:
     """A wrapper around :func:`~sympy.utilities.lambdify.lambdify`."""
-    # pylint: disable=import-outside-toplevel,too-many-return-statements
+    # pylint: disable=import-outside-toplevel, too-many-return-statements
     def jax_lambdify() -> Callable:
-        import jax
-
-        return jax.jit(
+        return jit_compile(
             sp.lambdify(
                 symbols,
                 expression,
                 modules=modules,
                 printer=_JaxPrinter,
                 **kwargs,
-            )
+            ),
+            backend="jax",
         )
 
     def numba_lambdify() -> Callable:
-        # pylint: disable=import-error
-        import numba
-
-        return numba.jit(
+        return jit_compile(
             sp.lambdify(symbols, expression, modules="numpy", **kwargs),
-            forceobj=True,
-            parallel=True,
+            backend="numba",
         )
 
     def tensorflow_lambdify() -> Callable:

--- a/src/tensorwaves/function/sympy.py
+++ b/src/tensorwaves/function/sympy.py
@@ -93,6 +93,8 @@ def split_expression(
         return sub_expression
 
     top_expression = recursive_split(expression)
+    remaining_symbols = top_expression.free_symbols - set(symbol_mapping)
+    symbol_mapping.update({s: s for s in remaining_symbols})
     remainder = progress_bar.total - progress_bar.n
     progress_bar.update(n=remainder)  # pylint crashes if total is set directly
     progress_bar.close()

--- a/src/tensorwaves/function/sympy.py
+++ b/src/tensorwaves/function/sympy.py
@@ -54,7 +54,7 @@ class _JaxPrinter(NumPyPrinter):  # pylint: disable=abstract-method
 def split_expression(
     expression: sp.Expr,
     max_complexity: int,
-    min_complexity: int = 0,
+    min_complexity: int = 1,
 ) -> Tuple[sp.Expr, Dict[sp.Symbol, sp.Expr]]:
     """Split an expression into a 'top expression' and several sub-expressions.
 
@@ -81,7 +81,7 @@ def split_expression(
         nonlocal i
         for arg in sub_expression.args:
             complexity = sp.count_ops(arg)
-            if min_complexity < complexity < max_complexity:
+            if min_complexity <= complexity <= max_complexity:
                 progress_bar.update(n=complexity)
                 symbol = sp.Symbol(f"f{i}")
                 i += 1

--- a/src/tensorwaves/function/sympy.py
+++ b/src/tensorwaves/function/sympy.py
@@ -68,21 +68,19 @@ def lambdify(
     """A wrapper around :func:`~sympy.utilities.lambdify.lambdify`."""
     # pylint: disable=import-outside-toplevel, too-many-return-statements
     def jax_lambdify() -> Callable:
-        return jit_compile(
+        return jit_compile(backend="jax")(
             sp.lambdify(
                 symbols,
                 expression,
                 modules=modules,
                 printer=_JaxPrinter,
                 **kwargs,
-            ),
-            backend="jax",
+            )
         )
 
     def numba_lambdify() -> Callable:
-        return jit_compile(
-            sp.lambdify(symbols, expression, modules="numpy", **kwargs),
-            backend="numba",
+        return jit_compile(backend="numba")(
+            sp.lambdify(symbols, expression, modules="numpy", **kwargs)
         )
 
     def tensorflow_lambdify() -> Callable:
@@ -149,6 +147,7 @@ def fast_lambdify(
         sub_function = lambdify(sub_expression, symbols, backend, **kwargs)
         sub_functions.append(sub_function)
 
+    @jit_compile(backend)  # type: ignore[arg-type]
     def recombined_function(*args: Any) -> Any:
         new_args = [sub_function(*args) for sub_function in sub_functions]
         return top_function(*new_args)

--- a/src/tensorwaves/function/sympy.py
+++ b/src/tensorwaves/function/sympy.py
@@ -68,7 +68,7 @@ def split_expression(
     i = 0
     symbol_mapping: Dict[sp.Symbol, sp.Expr] = {}
     n_operations = sp.count_ops(expression)
-    if n_operations < max_complexity:
+    if max_complexity <= 0 or n_operations < max_complexity:
         return expression, symbol_mapping
     progress_bar = tqdm(
         total=n_operations,

--- a/tests/unit/function/test_sympy.py
+++ b/tests/unit/function/test_sympy.py
@@ -28,15 +28,15 @@ def test_fast_lambdify(backend: str, max_complexity: int):
 
     func_repr = str(function)
     if 0 < max_complexity <= 4:
-        assert func_repr.startswith("<function fast_lambdify.<locals>")
+        repr_start = "<function fast_lambdify.<locals>"
     else:
         repr_start = "<function _lambdifygenerated"
-        if backend == "jax":
-            if sys.version_info >= (3, 7):
-                repr_start = "<CompiledFunction of " + repr_start
-            else:
-                repr_start = "<CompiledFunction object at 0x"
-        assert func_repr.startswith(repr_start)
+    if backend == "jax":
+        if sys.version_info >= (3, 7):
+            repr_start = "<CompiledFunction of " + repr_start
+        else:
+            repr_start = "<CompiledFunction object at 0x"
+    assert func_repr.startswith(repr_start)
 
     data = (
         4,

--- a/tests/unit/function/test_sympy.py
+++ b/tests/unit/function/test_sympy.py
@@ -1,5 +1,6 @@
 # cspell:ignore lambdifygenerated
 import sys
+from typing import Tuple
 
 import numpy as np
 import pytest
@@ -8,24 +9,25 @@ import sympy as sp
 from tensorwaves.function.sympy import fast_lambdify, split_expression
 
 
-def create_expression(x, y, z):
-    return x ** z + 2 * y
+def create_expression(a, x, y, z) -> sp.Expr:
+    return a * (x ** z + 2 * y)
 
 
 @pytest.mark.parametrize("backend", ["jax", "math", "numpy", "tf"])
-@pytest.mark.parametrize("max_complexity", [0, 2, 3, 4])
+@pytest.mark.parametrize("max_complexity", [0, 1, 2, 3, 4, 5])
 def test_fast_lambdify(backend: str, max_complexity: int):
-    x, y, z = sp.symbols("x y z")
-    expression = create_expression(x, y, z)
+    symbols: Tuple[sp.Symbol, ...] = sp.symbols("a x y z")
+    a, x, y, z = symbols
+    expression = create_expression(a, x, y, z)
     function = fast_lambdify(
         expression,
-        symbols=[x, y, z],
-        max_complexity=max_complexity,
+        symbols,
         backend=backend,
+        max_complexity=max_complexity,
     )
 
     func_repr = str(function)
-    if max_complexity <= 3:
+    if max_complexity <= 4:
         assert func_repr.startswith("<function fast_lambdify.<locals>")
     else:
         repr_start = "<function _lambdifygenerated"
@@ -37,6 +39,7 @@ def test_fast_lambdify(backend: str, max_complexity: int):
         assert func_repr.startswith(repr_start)
 
     data = (
+        4,
         np.array([1, 2]),
         np.array([1, np.e]),
         np.array([1, 2]),
@@ -47,14 +50,29 @@ def test_fast_lambdify(backend: str, max_complexity: int):
 
 
 def test_split_expression():
-    x, y, z = sp.symbols("x y z")
-    expression = create_expression(x, y, z)
-    top_expr, sub_expressions = split_expression(expression, max_complexity=2)
+    symbols: Tuple[sp.Symbol, ...] = sp.symbols("a x y z")
+    a, x, y, z = symbols
+    expression = create_expression(a, x, y, z)
+
+    assert expression.args[0] is a
+    assert len(expression.args[1].args) == 2
+    sub_expr, _ = expression.args[1].args
+    assert sub_expr == x ** z
+    n_nodes = sp.count_ops(sub_expr)
+    assert n_nodes == 1
+
+    top_expr, sub_expressions = split_expression(
+        expression,
+        min_complexity=n_nodes,
+        max_complexity=n_nodes,
+    )
     assert top_expr.free_symbols == set(sub_expressions)
     assert expression == top_expr.xreplace(sub_expressions)
 
     sub_symbols = sorted(top_expr.free_symbols, key=lambda s: s.name)
-    assert len(sub_symbols) == 2
-    f1, f2 = tuple(sub_symbols)
+    assert len(sub_symbols) == 3
+    f0, f1, f2 = tuple(sub_symbols)
+    assert f0 is a
+    assert sub_expressions[f0] == a
     assert sub_expressions[f1] == x ** z
     assert sub_expressions[f2] == 2 * y

--- a/tests/unit/function/test_sympy.py
+++ b/tests/unit/function/test_sympy.py
@@ -27,7 +27,7 @@ def test_fast_lambdify(backend: str, max_complexity: int):
     )
 
     func_repr = str(function)
-    if max_complexity <= 4:
+    if 0 < max_complexity <= 4:
         assert func_repr.startswith("<function fast_lambdify.<locals>")
     else:
         repr_start = "<function _lambdifygenerated"

--- a/tests/unit/function/test_sympy.py
+++ b/tests/unit/function/test_sympy.py
@@ -13,7 +13,7 @@ def create_expression(x, y, z):
 
 
 @pytest.mark.parametrize("backend", ["jax", "math", "numpy", "tf"])
-@pytest.mark.parametrize("max_complexity", [2, 3, 4])
+@pytest.mark.parametrize("max_complexity", [0, 2, 3, 4])
 def test_fast_lambdify(backend: str, max_complexity: int):
     x, y, z = sp.symbols("x y z")
     expression = create_expression(x, y, z)
@@ -49,7 +49,7 @@ def test_fast_lambdify(backend: str, max_complexity: int):
 def test_split_expression():
     x, y, z = sp.symbols("x y z")
     expression = create_expression(x, y, z)
-    top_expr, sub_expressions = split_expression(expression, max_complexity=3)
+    top_expr, sub_expressions = split_expression(expression, max_complexity=2)
     assert top_expr.free_symbols == set(sub_expressions)
     assert expression == top_expr.xreplace(sub_expressions)
 


### PR DESCRIPTION
#348 introduced a bug: the recombined function was not JIT-compiled, which significantly slowed down performance. This was temporarily avoided in #359.

| GitHub Action | b920c77 (no JIT) | 80e542c (with JIT) |
| --- | --- | --- |
| ci-docs | [9m 6s](https://github.com/ComPWA/tensorwaves/actions/runs/1526379716) | [7m 21s](https://github.com/ComPWA/tensorwaves/actions/runs/1526435002) |
| pytest-cov | [2m 10s](https://github.com/ComPWA/tensorwaves/runs/4383088855?check_suite_focus=true) | [1m 20s](https://github.com/ComPWA/tensorwaves/runs/4383253350?check_suite_focus=true) |