### PR TITLE
feat: speed up imports

### DIFF
--- a/docs/abbreviate_signature.py
+++ b/docs/abbreviate_signature.py
@@ -17,6 +17,7 @@ from sphinx.environment import BuildEnvironment
 
 def replace_link(text: str) -> str:
     replacements = {
+        "HelicityAdapter": "ampform.kinematics.HelicityAdapter",
         "a set-like object providing a view on D's items": "typing.ItemsView",
         "a set-like object providing a view on D's keys": "typing.KeysView",
         "an object providing a view on D's values": "typing.ValuesView",

--- a/src/tensorwaves/data/__init__.py
+++ b/src/tensorwaves/data/__init__.py
@@ -4,7 +4,6 @@ import logging
 from typing import Mapping, Optional, Tuple
 
 import numpy as np
-from ampform.data import EventCollection
 from tqdm.auto import tqdm
 
 from tensorwaves.data.phasespace import (
@@ -56,6 +55,9 @@ def generate_data(  # pylint: disable=too-many-arguments
             generated from many smaller samples, aka bunches.
 
     """
+    # pylint: disable=import-outside-toplevel
+    from ampform.data import EventCollection
+
     if phsp_generator is None:
         phsp_gen_instance = TFPhaseSpaceGenerator()
     phsp_gen_instance.setup(initial_state_mass, final_state_masses)
@@ -105,6 +107,9 @@ def _generate_data_bunch(
     intensity: Function,
     kinematics: DataTransformer,
 ) -> Tuple[DataSample, float]:
+    # pylint: disable=import-outside-toplevel
+    from ampform.data import EventCollection
+
     phsp_sample, weights = phsp_generator.generate(
         bunch_size, random_generator
     )
@@ -143,6 +148,9 @@ def generate_phsp(
             generated from many smaller samples, aka bunches.
 
     """
+    # pylint: disable=import-outside-toplevel
+    from ampform.data import EventCollection
+
     if phsp_generator is None:
         phsp_generator = TFPhaseSpaceGenerator()
     phsp_generator.setup(initial_state_mass, final_state_masses)

--- a/src/tensorwaves/data/phasespace.py
+++ b/src/tensorwaves/data/phasespace.py
@@ -1,11 +1,9 @@
+# pylint: disable=import-outside-toplevel
 """Implementations of `.PhaseSpaceGenerator` and `.UniformRealNumberGenerator`."""
 
 from typing import Mapping, Optional, Tuple
 
 import numpy as np
-import phasespace
-import tensorflow as tf
-from phasespace.random import get_rng
 
 from tensorwaves.interface import (
     DataSample,
@@ -25,6 +23,8 @@ class TFPhaseSpaceGenerator(PhaseSpaceGenerator):
         initial_state_mass: float,
         final_state_masses: Mapping[int, float],
     ) -> None:
+        import phasespace
+
         sorted_ids = sorted(final_state_masses)
         self.__phsp_gen = phasespace.nbody_decay(
             mass_top=initial_state_mass,
@@ -57,8 +57,10 @@ class TFUniformRealNumberGenerator(UniformRealNumberGenerator):
     """Implements a uniform real random number generator using tensorflow."""
 
     def __init__(self, seed: Optional[float] = None):
+        from tensorflow import float64
+
         self.seed = seed
-        self.dtype = tf.float64
+        self.dtype = float64
 
     def __call__(
         self, size: int, min_value: float = 0.0, max_value: float = 1.0
@@ -76,5 +78,7 @@ class TFUniformRealNumberGenerator(UniformRealNumberGenerator):
 
     @seed.setter
     def seed(self, value: Optional[float]) -> None:
+        from phasespace.random import get_rng
+
         self.__seed = value
         self.generator = get_rng(self.seed)

--- a/src/tensorwaves/data/transform.py
+++ b/src/tensorwaves/data/transform.py
@@ -1,9 +1,13 @@
 """Implementations of `.DataTransformer`."""
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-from ampform.kinematics import EventCollection, HelicityAdapter
 
 from tensorwaves.interface import DataSample, DataTransformer
+
+if TYPE_CHECKING:
+    from ampform.kinematics import HelicityAdapter
 
 
 class HelicityTransformer(DataTransformer):
@@ -13,10 +17,13 @@ class HelicityTransformer(DataTransformer):
     `~ampform.kinematics.HelicityAdapter`.
     """
 
-    def __init__(self, helicity_adapter: HelicityAdapter) -> None:
+    def __init__(self, helicity_adapter: "HelicityAdapter") -> None:
         self.__helicity_adapter = helicity_adapter
 
     def __call__(self, dataset: DataSample) -> DataSample:
+        # pylint: disable=import-outside-toplevel
+        from ampform.kinematics import EventCollection
+
         events = EventCollection({int(k): v for k, v in dataset.items()})
         dataset = self.__helicity_adapter.transform(events)
         return {key: np.array(values) for key, values in dataset.items()}

--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import IO, Any, Dict, Iterable, List, Optional, Union
 
 import numpy as np
-import tensorflow as tf
 import yaml
 
 from tensorwaves.interface import ParameterValue
@@ -240,7 +239,9 @@ class TFSummary(Callback):
         self.__file_writer = open(os.devnull, "w")
 
     def on_optimize_start(self, logs: Optional[Dict[str, Any]] = None) -> None:
-        # pylint: disable=no-member
+        # pylint: disable=import-outside-toplevel, no-member
+        import tensorflow as tf
+
         output_dir = (
             self.__logdir + "/" + datetime.now().strftime("%Y%m%d-%H%M%S")
         )
@@ -261,7 +262,9 @@ class TFSummary(Callback):
     def on_function_call_end(
         self, function_call: int, logs: Optional[Dict[str, Any]] = None
     ) -> None:
-        # pylint: disable=no-member
+        # pylint: disable=import-outside-toplevel, no-member
+        import tensorflow as tf
+
         if logs is None:
             return
         if function_call % self.__step_size != 0:

--- a/src/tensorwaves/optimizer/scipy.py
+++ b/src/tensorwaves/optimizer/scipy.py
@@ -6,7 +6,6 @@ import time
 from datetime import datetime
 from typing import Any, Dict, Iterable, Mapping, Optional
 
-from scipy.optimize import minimize
 from tqdm.auto import tqdm
 
 from tensorwaves.interface import (
@@ -46,6 +45,9 @@ class ScipyMinimizer(Optimizer):
         estimator: Estimator,
         initial_parameters: Mapping[str, ParameterValue],
     ) -> FitResult:
+        # pylint: disable=import-outside-toplevel
+        from scipy.optimize import minimize
+
         parameter_handler = ParameterFlattener(initial_parameters)
         flattened_parameters = parameter_handler.flatten(initial_parameters)
 

--- a/tests/unit/test_backend.py
+++ b/tests/unit/test_backend.py
@@ -1,13 +1,13 @@
-# pylint: disable=import-error
-# pyright: reportMissingImports=false
-import jax.numpy as jnp
-import numpy as np
-import tensorflow.experimental.numpy as tnp
-
 from tensorwaves._backend import find_function
 
 
 def test_find_function():
+    # pylint: disable=import-error, import-outside-toplevel
+    # pyright: reportMissingImports=false
+    import jax.numpy as jnp
+    import numpy as np
+    import tensorflow.experimental.numpy as tnp
+
     assert find_function("mean", backend="numpy") is np.mean
     assert find_function("log", backend="numpy") is np.log
     assert find_function("mean", backend="tf") is tnp.mean

--- a/tox.ini
+++ b/tox.ini
@@ -111,12 +111,10 @@ passenv = HOME
 description =
     Perform all linting, formatting, and spelling checks
 setenv =
-    SKIP = mypy, pyright
+    SKIP = pyright
 allowlist_externals =
-    mypy
     pre-commit
 commands =
-    mypy src tests # run separately because of potential caching problems
     pre-commit run {posargs} -a
 
 [testenv:test]


### PR DESCRIPTION
Import expensive modules inline to speed up importing `tensorwaves`. This makes `import tensorwaves` (and collecting tests) about 8x as fast. Profiling done with [tuna](https://github.com/nschloe/tuna) as follows (see [stackoverflow](https://stackoverflow.com/a/51300944)):

```shell
python3 -X importtime -c "import tensorwaves" 2> tw.log && tuna tw.log
```