### PR TITLE
ci: avoid callbacks if unspecified

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ addopts =
     --ignore=docs/conf.py
     --ignore-glob=*/.ipynb_checkpoints/*
 filterwarnings =
+    error
     ignore:.*Using or importing the ABCs.*:DeprecationWarning
     ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning
     ignore:Passing a schema to Validator.iter_errors is deprecated.*:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     ampform >=0.10, !=0.11.2, <0.12
+    attrs >=20.1.0  # https://www.attrs.org/en/stable/api.html#next-gen
     iminuit >=2.0
     numpy
     phasespace >=1.2.0, <1.5.0  # https://github.com/zfit/phasespace/pull/69

--- a/src/tensorwaves/interface.py
+++ b/src/tensorwaves/interface.py
@@ -96,7 +96,7 @@ _PARAMETER_DICT_VALIDATOR = attr.validators.deep_mapping(
 )
 
 
-@attr.s(frozen=True)
+@attr.frozen
 class FitResult:  # pylint: disable=too-many-instance-attributes
     minimum_valid: bool = attr.ib(validator=instance_of(bool))
     execution_time: float = attr.ib(validator=instance_of(float))

--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -250,9 +250,6 @@ class TFSummary(Callback):
         self.__step_size = step_size
         self.__stream: Optional[Any] = None
 
-    def __del__(self) -> None:
-        _close_stream(self.__stream)
-
     def on_optimize_start(self, logs: Optional[Dict[str, Any]] = None) -> None:
         # pylint: disable=import-outside-toplevel, no-member
         import tensorflow as tf
@@ -262,12 +259,12 @@ class TFSummary(Callback):
         )
         if self.__subdir is not None:
             output_dir += "/" + self.__subdir
-        _close_stream(self.__stream)
         self.__stream = tf.summary.create_file_writer(output_dir)
         self.__stream.set_as_default()  # type: ignore[attr-defined]
 
     def on_optimize_end(self, logs: Optional[Dict[str, Any]] = None) -> None:
-        _close_stream(self.__stream)
+        if self.__stream:
+            self.__stream.close()
 
     def on_iteration_end(
         self, iteration: int, logs: Optional[Dict[str, Any]] = None

--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -67,6 +67,15 @@ class CallbackList(Callback):
         for callback in callbacks:
             self.__callbacks.append(callback)
 
+    @property
+    def callbacks(self) -> List[Callback]:
+        return list(self.__callbacks)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, CallbackList):
+            return self.callbacks == other.callbacks
+        return False
+
     def on_optimize_start(self, logs: Optional[Dict[str, Any]] = None) -> None:
         for callback in self.__callbacks:
             callback.on_optimize_start(logs)

--- a/src/tensorwaves/optimizer/minuit.py
+++ b/src/tensorwaves/optimizer/minuit.py
@@ -73,14 +73,16 @@ class Minuit2(Optimizer):
             estimator_value = float(estimator(parameters))
             progress_bar.set_postfix({"estimator": estimator_value})
             progress_bar.update()
-            logs = _create_log(
-                optimizer=type(self),
-                estimator_type=type(estimator),
-                estimator_value=estimator_value,
-                function_call=n_function_calls,
-                parameters=parameters,
+            self.callback.on_function_call_end(
+                n_function_calls,
+                logs=_create_log(
+                    optimizer=type(self),
+                    estimator_type=type(estimator),
+                    estimator_value=estimator_value,
+                    function_call=n_function_calls,
+                    parameters=parameters,
+                ),
             )
-            self.__callback.on_function_call_end(n_function_calls, logs)
             return estimator_value
 
         def wrapped_gradient(pars: list) -> Iterable[float]:

--- a/src/tensorwaves/optimizer/minuit.py
+++ b/src/tensorwaves/optimizer/minuit.py
@@ -4,9 +4,11 @@
 
 import logging
 import time
-from typing import Iterable, Mapping, Optional
+from typing import Iterable, Mapping
 
+import attr
 import iminuit
+from attr.validators import instance_of
 from tqdm.auto import tqdm
 
 from tensorwaves.interface import (
@@ -20,22 +22,18 @@ from ._parameter import ParameterFlattener
 from .callbacks import Callback, CallbackList, _create_log
 
 
+@attr.frozen
 class Minuit2(Optimizer):
     """Adapter to `Minuit2 <https://root.cern.ch/doc/master/Minuit2Page.html>`_.
 
     Implements the `~.interface.Optimizer` interface using `iminuit.Minuit`.
     """
 
-    def __init__(
-        self,
-        callback: Optional[Callback] = None,
-        use_analytic_gradient: bool = False,
-    ) -> None:
-        if callback is not None:
-            self.__callback = callback
-        else:
-            self.__callback = CallbackList([])
-        self.__use_gradient = use_analytic_gradient
+    use_analytic_gradient: bool = attr.ib(converter=bool, default=False)
+    callback: Callback = attr.ib(
+        validator=instance_of(Callback),  # type: ignore[arg-type, misc]
+        default=CallbackList([]),
+    )
 
     def optimize(  # pylint: disable=too-many-locals
         self,
@@ -51,7 +49,7 @@ class Minuit2(Optimizer):
         n_function_calls = 0
 
         parameters = parameter_handler.unflatten(flattened_parameters)
-        self.__callback.on_optimize_start(
+        self.callback.on_optimize_start(
             logs=_create_log(
                 optimizer=type(self),
                 estimator_type=type(estimator),
@@ -80,7 +78,7 @@ class Minuit2(Optimizer):
                 function_call=n_function_calls,
                 parameters=parameters,
             )
-            self.__callback.on_function_call_end(n_function_calls, logs)
+            self.callback.on_function_call_end(n_function_calls, logs)
             return estimator_value
 
         def wrapped_gradient(pars: list) -> Iterable[float]:
@@ -92,7 +90,7 @@ class Minuit2(Optimizer):
         minuit = iminuit.Minuit(
             wrapped_function,
             tuple(flattened_parameters.values()),
-            grad=wrapped_gradient if self.__use_gradient else None,
+            grad=wrapped_gradient if self.use_analytic_gradient else None,
             name=tuple(flattened_parameters),
         )
         minuit.errors = tuple(
@@ -116,7 +114,7 @@ class Minuit2(Optimizer):
         parameter_values = parameter_handler.unflatten(parameter_values)
         parameter_errors = parameter_handler.unflatten(parameter_errors)
 
-        self.__callback.on_optimize_end(
+        self.callback.on_optimize_end(
             logs=_create_log(
                 optimizer=type(self),
                 estimator_type=type(estimator),

--- a/src/tensorwaves/optimizer/minuit.py
+++ b/src/tensorwaves/optimizer/minuit.py
@@ -113,25 +113,24 @@ class Minuit2(Optimizer):
             parameter_values[name] = par_state.value
             parameter_errors[name] = par_state.error
 
-        parameter_values = parameter_handler.unflatten(parameter_values)
-        parameter_errors = parameter_handler.unflatten(parameter_errors)
+        fit_result = FitResult(
+            minimum_valid=minuit.valid,
+            execution_time=end_time - start_time,
+            function_calls=minuit.fmin.nfcn,
+            estimator_value=minuit.fmin.fval,
+            parameter_values=parameter_handler.unflatten(parameter_values),
+            parameter_errors=parameter_handler.unflatten(parameter_errors),
+            specifics=minuit,
+        )
 
         self.__callback.on_optimize_end(
             logs=_create_log(
                 optimizer=type(self),
                 estimator_type=type(estimator),
-                estimator_value=float(minuit.fmin.fval),
-                function_call=minuit.fmin.nfcn,
-                parameters=parameter_values,
+                estimator_value=fit_result.estimator_value,
+                function_call=fit_result.function_calls,
+                parameters=fit_result.parameter_values,
             )
         )
 
-        return FitResult(
-            minimum_valid=minuit.valid,
-            execution_time=end_time - start_time,
-            function_calls=minuit.fmin.nfcn,
-            estimator_value=minuit.fmin.fval,
-            parameter_values=parameter_values,
-            parameter_errors=parameter_errors,
-            specifics=minuit,
-        )
+        return fit_result

--- a/src/tensorwaves/optimizer/scipy.py
+++ b/src/tensorwaves/optimizer/scipy.py
@@ -88,14 +88,16 @@ class ScipyMinimizer(Optimizer):
             estimator_value = estimator(parameters)
             progress_bar.set_postfix({"estimator": estimator_value})
             progress_bar.update()
-            logs = _create_log(
-                optimizer=type(self),
-                estimator_type=type(estimator),
-                estimator_value=estimator(parameters),
-                function_call=n_function_calls,
-                parameters=parameters,
+            self.__callback.on_function_call_end(
+                n_function_calls,
+                logs=_create_log(
+                    optimizer=type(self),
+                    estimator_type=type(estimator),
+                    estimator_value=estimator(parameters),
+                    function_call=n_function_calls,
+                    parameters=parameters,
+                ),
             )
-            self.__callback.on_function_call_end(n_function_calls, logs)
             return float(estimator_value)
 
         def wrapped_gradient(pars: list) -> Iterable[float]:

--- a/src/tensorwaves/optimizer/scipy.py
+++ b/src/tensorwaves/optimizer/scipy.py
@@ -15,7 +15,7 @@ from tensorwaves.interface import (
 )
 
 from ._parameter import ParameterFlattener
-from .callbacks import Callback, CallbackList, _create_log
+from .callbacks import Callback, _create_log
 
 
 class ScipyMinimizer(Optimizer):
@@ -31,10 +31,7 @@ class ScipyMinimizer(Optimizer):
         use_analytic_gradient: bool = False,
         **scipy_options: Dict[Any, Any],
     ) -> None:
-        if callback is not None:
-            self.__callback = callback
-        else:
-            self.__callback = CallbackList([])
+        self.__callback = callback
         self.__use_gradient = use_analytic_gradient
         self.__method = method
         self.__minimize_options = scipy_options
@@ -58,15 +55,16 @@ class ScipyMinimizer(Optimizer):
         estimator_value = 0.0
 
         parameters = parameter_handler.unflatten(flattened_parameters)
-        self.__callback.on_optimize_start(
-            logs=_create_log(
-                optimizer=type(self),
-                estimator_type=type(estimator),
-                estimator_value=estimator(parameters),
-                function_call=n_function_calls,
-                parameters=parameters,
+        if self.__callback is not None:
+            self.__callback.on_optimize_start(
+                logs=_create_log(
+                    optimizer=type(self),
+                    estimator_type=type(estimator),
+                    estimator_value=estimator(parameters),
+                    function_call=n_function_calls,
+                    parameters=parameters,
+                )
             )
-        )
 
         def update_parameters(pars: list) -> None:
             for i, k in enumerate(flattened_parameters):
@@ -88,16 +86,17 @@ class ScipyMinimizer(Optimizer):
             estimator_value = estimator(parameters)
             progress_bar.set_postfix({"estimator": estimator_value})
             progress_bar.update()
-            self.__callback.on_function_call_end(
-                n_function_calls,
-                logs=_create_log(
-                    optimizer=type(self),
-                    estimator_type=type(estimator),
-                    estimator_value=estimator(parameters),
-                    function_call=n_function_calls,
-                    parameters=parameters,
-                ),
-            )
+            if self.__callback is not None:
+                self.__callback.on_function_call_end(
+                    n_function_calls,
+                    logs=_create_log(
+                        optimizer=type(self),
+                        estimator_type=type(estimator),
+                        estimator_value=estimator(parameters),
+                        function_call=n_function_calls,
+                        parameters=parameters,
+                    ),
+                )
             return float(estimator_value)
 
         def wrapped_gradient(pars: list) -> Iterable[float]:
@@ -109,16 +108,17 @@ class ScipyMinimizer(Optimizer):
         def wrapped_callback(pars: Iterable[float]) -> None:
             nonlocal iterations
             iterations += 1
-            self.__callback.on_iteration_end(
-                iterations,
-                logs=_create_log(
-                    optimizer=type(self),
-                    estimator_type=type(estimator),
-                    estimator_value=float(estimator_value),
-                    function_call=n_function_calls,
-                    parameters=create_parameter_dict(pars),
-                ),
-            )
+            if self.__callback is not None:
+                self.__callback.on_iteration_end(
+                    iterations,
+                    logs=_create_log(
+                        optimizer=type(self),
+                        estimator_type=type(estimator),
+                        estimator_value=float(estimator_value),
+                        function_call=n_function_calls,
+                        parameters=create_parameter_dict(pars),
+                    ),
+                )
 
         start_time = time.time()
         fit_result = minimize(
@@ -140,13 +140,14 @@ class ScipyMinimizer(Optimizer):
             iterations=fit_result.nit,
             specifics=fit_result,
         )
-        self.__callback.on_optimize_end(
-            logs=_create_log(
-                optimizer=type(self),
-                estimator_type=type(estimator),
-                estimator_value=fit_result.estimator_value,
-                function_call=fit_result.function_calls,
-                parameters=fit_result.parameter_values,
+        if self.__callback is not None:
+            self.__callback.on_optimize_end(
+                logs=_create_log(
+                    optimizer=type(self),
+                    estimator_type=type(estimator),
+                    estimator_value=fit_result.estimator_value,
+                    function_call=fit_result.function_calls,
+                    parameters=fit_result.parameter_values,
+                )
             )
-        )
         return fit_result

--- a/tests/unit/optimizer/test_minuit.py
+++ b/tests/unit/optimizer/test_minuit.py
@@ -5,7 +5,6 @@ import pytest
 from pytest_mock import MockerFixture
 
 from tensorwaves.interface import Estimator, ParameterValue
-from tensorwaves.optimizer.callbacks import CallbackList
 from tensorwaves.optimizer.minuit import Minuit2
 
 from . import CallbackMock, assert_invocations
@@ -41,13 +40,6 @@ class Polynomial2DMinimaEstimator(Estimator):
 
 
 class TestMinuit2:
-    def test_minuit2_init(self):
-        with pytest.raises(TypeError):
-            Minuit2(callback="faulty argument")  # type: ignore[arg-type]
-        optimizer = Minuit2(use_analytic_gradient=True)
-        assert optimizer.callback == CallbackList([])
-        assert optimizer.use_analytic_gradient
-
     def test_mock_callback(self, mocker: MockerFixture) -> None:
         estimator = Polynomial1DMinimaEstimator(lambda x: x ** 2 - 1)
         initial_params = {"x": 0.5}

--- a/tests/unit/optimizer/test_minuit.py
+++ b/tests/unit/optimizer/test_minuit.py
@@ -1,4 +1,4 @@
-# pylint: disable=unsubscriptable-object
+# pylint: disable=no-self-use, unsubscriptable-object
 from typing import Callable, Dict, Mapping, Optional
 
 import pytest
@@ -39,72 +39,77 @@ class Polynomial2DMinimaEstimator(Estimator):
         return NotImplemented
 
 
-@pytest.mark.parametrize(
-    ("estimator", "initial_params", "expected_result"),
-    [
-        (
-            Polynomial1DMinimaEstimator(lambda x: x ** 2 - 1),
-            {"x": 0.5},
-            {"x": 0.0},
-        ),
-        (
-            Polynomial1DMinimaEstimator(lambda x: x ** 2 - 1),
-            {"x": -0.5},
-            {"x": 0.0},
-        ),
-        (
-            Polynomial1DMinimaEstimator(lambda x: (x - 1) ** 2 - 3 * x + 1),
-            {"x": -0.5},
-            {"x": 2.5},  # 2 (x - 1) - 3 == 0 -> x = 3/2 + 1
-        ),
-        (
-            Polynomial1DMinimaEstimator(
-                lambda x: x ** 3 + (x - 1) ** 2 - 3 * x + 1
+class TestMinuit2:
+    def test_mock_callback(self, mocker: MockerFixture) -> None:
+        estimator = Polynomial1DMinimaEstimator(lambda x: x ** 2 - 1)
+        initial_params = {"x": 0.5}
+
+        callback_stub = mocker.stub(name="callback_stub")
+        minuit2 = Minuit2(callback=CallbackMock(callback_stub))
+        minuit2.optimize(estimator, initial_params)
+
+        assert_invocations(callback_stub)
+
+    @pytest.mark.parametrize(
+        ("estimator", "initial_params", "expected_result"),
+        [
+            (
+                Polynomial1DMinimaEstimator(lambda x: x ** 2 - 1),
+                {"x": 0.5},
+                {"x": 0.0},
             ),
-            {"x": -1.0},
-            {"x": 1.0},
-        ),
-        (
-            Polynomial1DMinimaEstimator(
-                lambda x: x ** 3 + (x - 1) ** 2 - 3 * x + 1
+            (
+                Polynomial1DMinimaEstimator(lambda x: x ** 2 - 1),
+                {"x": -0.5},
+                {"x": 0.0},
             ),
-            {"x": -2.0},
-            None,  # no convergence
-        ),
-        (
-            Polynomial2DMinimaEstimator(
-                lambda x, y: (x - 1) ** 2 + (y + 1) ** 2
+            (
+                Polynomial1DMinimaEstimator(
+                    lambda x: (x - 1) ** 2 - 3 * x + 1
+                ),
+                {"x": -0.5},
+                {"x": 2.5},  # 2 (x - 1) - 3 == 0 -> x = 3/2 + 1
             ),
-            {"x": -2.0, "y": 4.0},
-            {"x": 1.0, "y": -1.0},
-        ),
-    ],
-)
-def test_minuit2(
-    estimator: Estimator, initial_params: dict, expected_result: Optional[dict]
-):
-    minuit2 = Minuit2()
-    fit_result = minuit2.optimize(estimator, initial_params)
+            (
+                Polynomial1DMinimaEstimator(
+                    lambda x: x ** 3 + (x - 1) ** 2 - 3 * x + 1
+                ),
+                {"x": -1.0},
+                {"x": 1.0},
+            ),
+            (
+                Polynomial1DMinimaEstimator(
+                    lambda x: x ** 3 + (x - 1) ** 2 - 3 * x + 1
+                ),
+                {"x": -2.0},
+                None,  # no convergence
+            ),
+            (
+                Polynomial2DMinimaEstimator(
+                    lambda x, y: (x - 1) ** 2 + (y + 1) ** 2
+                ),
+                {"x": -2.0, "y": 4.0},
+                {"x": 1.0, "y": -1.0},
+            ),
+        ],
+    )
+    def test_optimize(
+        self,
+        estimator: Estimator,
+        initial_params: dict,
+        expected_result: Optional[dict],
+    ):
+        minuit2 = Minuit2()
+        fit_result = minuit2.optimize(estimator, initial_params)
 
-    par_values = fit_result.parameter_values
-    par_errors = fit_result.parameter_errors
-    assert par_errors is not None
+        par_values = fit_result.parameter_values
+        par_errors = fit_result.parameter_errors
+        assert par_errors is not None
 
-    if expected_result:
-        for par_name, value in expected_result.items():
-            assert value == pytest.approx(
-                par_values[par_name], abs=3 * par_errors[par_name]
-            )
-    else:
-        assert fit_result.minimum_valid is False
-
-
-def test_callback(mocker: MockerFixture) -> None:
-    estimator = Polynomial1DMinimaEstimator(lambda x: x ** 2 - 1)
-    initial_params = {"x": 0.5}
-
-    callback_stub = mocker.stub(name="callback_stub")
-    minuit2 = Minuit2(callback=CallbackMock(callback_stub))
-    minuit2.optimize(estimator, initial_params)
-
-    assert_invocations(callback_stub)
+        if expected_result:
+            for par_name, value in expected_result.items():
+                assert value == pytest.approx(
+                    par_values[par_name], abs=3 * par_errors[par_name]
+                )
+        else:
+            assert fit_result.minimum_valid is False

--- a/tests/unit/optimizer/test_minuit.py
+++ b/tests/unit/optimizer/test_minuit.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from tensorwaves.interface import Estimator, ParameterValue
+from tensorwaves.optimizer.callbacks import CallbackList
 from tensorwaves.optimizer.minuit import Minuit2
 
 from . import CallbackMock, assert_invocations
@@ -40,6 +41,13 @@ class Polynomial2DMinimaEstimator(Estimator):
 
 
 class TestMinuit2:
+    def test_minuit2_init(self):
+        with pytest.raises(TypeError):
+            Minuit2(callback="faulty argument")  # type: ignore[arg-type]
+        optimizer = Minuit2(use_analytic_gradient=True)
+        assert optimizer.callback == CallbackList([])
+        assert optimizer.use_analytic_gradient
+
     def test_mock_callback(self, mocker: MockerFixture) -> None:
         estimator = Polynomial1DMinimaEstimator(lambda x: x ** 2 - 1)
         initial_params = {"x": 0.5}


### PR DESCRIPTION
Previously, if no callback was specified in the optimizer constructor, an empty CallbackList would be created and on_optimize_end etc were always called. This is (theoretically) slower.

Some other improvements:
- Use [`attrs` next-generation API](https://www.attrs.org/en/stable/api.html#next-gen) (see also https://github.com/ComPWA/compwa-org/issues/90).
- Avoid creating stream on creation of Loadable callback.
- Fail pytest on warnings (this helped fishing out the above bug)