### PR TITLE
ci: speed up pytest collect

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -30,7 +30,7 @@ jobs:
           pip install -c .constraints/py${{ matrix.python-version }}.txt -e .[test]
           pip install .
       - name: Test with pytest-cov
-        run: pytest -n auto --cov=tensorwaves --cov-report=xml
+        run: pytest tests -n auto --cov=tensorwaves --cov-report=xml
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -30,7 +30,7 @@ jobs:
           pip install -c .constraints/py${{ matrix.python-version }}.txt -e .[test]
           pip install .
       - name: Test with pytest-cov
-        run: pytest tests -n auto --cov=tensorwaves --cov-report=xml
+        run: pytest -n auto --cov=tensorwaves --cov-report=xml
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:

--- a/benchmarks/ampform.py
+++ b/benchmarks/ampform.py
@@ -1,29 +1,39 @@
-# pylint: disable=no-self-use
+# pylint: disable=import-outside-toplevel, no-self-use
 from pprint import pprint
-from typing import List, Mapping, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, Tuple
 
-import ampform
 import numpy as np
 import pytest
-import qrules
-from ampform.dynamics.builder import create_relativistic_breit_wigner_with_ff
-from ampform.helicity import HelicityModel, ParameterValue
-from qrules.combinatorics import StateDefinition
 
 import tensorwaves as tw
 from tensorwaves.data.phasespace import TFUniformRealNumberGenerator
 from tensorwaves.data.transform import HelicityTransformer
 from tensorwaves.function.sympy import create_parametrized_function
-from tensorwaves.interface import DataSample, FitResult, ParametrizedFunction
+from tensorwaves.interface import (
+    DataSample,
+    FitResult,
+    ParameterValue,
+    ParametrizedFunction,
+)
+
+if TYPE_CHECKING:
+    from ampform.helicity import HelicityModel
+    from qrules.combinatorics import StateDefinition
 
 
 def formulate_amplitude_model(
     formalism: str,
-    initial_state: StateDefinition,
-    final_state: Sequence[StateDefinition],
+    initial_state: "StateDefinition",
+    final_state: Sequence["StateDefinition"],
     intermediate_states: Optional[List[str]] = None,
     interaction_types: Optional[List[str]] = None,
-) -> HelicityModel:
+) -> "HelicityModel":
+    import ampform
+    import qrules
+    from ampform.dynamics.builder import (
+        create_relativistic_breit_wigner_with_ff,
+    )
+
     reaction = qrules.generate_transitions(
         initial_state=initial_state,
         final_state=final_state,
@@ -39,7 +49,7 @@ def formulate_amplitude_model(
 
 
 def create_function(
-    model: HelicityModel, backend: str, max_complexity: Optional[int] = None
+    model: "HelicityModel", backend: str, max_complexity: Optional[int] = None
 ) -> ParametrizedFunction:
     return create_parametrized_function(
         expression=model.expression.doit(),
@@ -50,7 +60,7 @@ def create_function(
 
 
 def generate_data(
-    model: HelicityModel,
+    model: "HelicityModel",
     function: ParametrizedFunction,
     data_sample_size: int,
     phsp_sample_size: int,
@@ -125,7 +135,7 @@ class TestJPsiToGammaPiPi:
     }
 
     @pytest.fixture(scope="session")
-    def model(self) -> HelicityModel:
+    def model(self) -> "HelicityModel":
         return formulate_amplitude_model(
             formalism="canonical-helicity",
             initial_state=("J/psi(1S)", [-1, +1]),

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,10 +21,12 @@ filterwarnings =
     ignore:invalid value encountered in log.*:RuntimeWarning
     ignore:invalid value encountered in sqrt:RuntimeWarning
     ignore:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
-norecursedirs =
-    _build
 markers =
     slow: marks tests as slow (select with '-m slow')
+norecursedirs =
+    _build
+    docs/api
+    tests/output
 testpaths =
     benchmarks
     src

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,19 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-import qrules
 from _pytest.config import Config as PytestConfig
+
+if TYPE_CHECKING:
+    from qrules import ParticleCollection
 
 
 @pytest.fixture(scope="session")
-def pdg() -> qrules.ParticleCollection:
-    return qrules.particle.load_pdg()
+def pdg() -> "ParticleCollection":
+    # pylint: disable=import-outside-toplevel
+    from qrules.particle import load_pdg
+
+    return load_pdg()
 
 
 @pytest.fixture(scope="session")

--- a/tests/data/test_generate.py
+++ b/tests/data/test_generate.py
@@ -1,12 +1,14 @@
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
 import pytest
-from qrules.particle import ParticleCollection
 
 from tensorwaves.data import generate_data, generate_phsp
 from tensorwaves.data.phasespace import TFUniformRealNumberGenerator
 from tensorwaves.interface import DataSample, DataTransformer, Function
+
+if TYPE_CHECKING:
+    from qrules import ParticleCollection
 
 
 class FlatDistribution(Function[DataSample, np.ndarray]):
@@ -133,7 +135,7 @@ def test_generate_phsp(
     initial_state: str,
     final_state: Sequence[str],
     expected_sample: DataSample,
-    pdg: ParticleCollection,
+    pdg: "ParticleCollection",
 ):
     sample_size = 3
     rng = TFUniformRealNumberGenerator(seed=0)

--- a/tests/data/test_phasespace.py
+++ b/tests/data/test_phasespace.py
@@ -1,18 +1,21 @@
 from pprint import pprint
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
-from qrules import ParticleCollection
 
 from tensorwaves.data.phasespace import (
     TFPhaseSpaceGenerator,
     TFUniformRealNumberGenerator,
 )
 
+if TYPE_CHECKING:
+    from qrules import ParticleCollection
+
 
 class TestTFPhaseSpaceGenerator:
     @staticmethod
-    def test_generate_deterministic(pdg: ParticleCollection):
+    def test_generate_deterministic(pdg: "ParticleCollection"):
         sample_size = 5
         initial_state_name = "J/psi(1S)"
         final_state_names = ["K0", "Sigma+", "p~"]

--- a/tox.ini
+++ b/tox.ini
@@ -25,14 +25,10 @@ description =
     Run benchmark tests and visualize in histogram
 allowlist_externals =
     pytest
-deps =
-    pygal
-    pygaljs
 commands =
     pytest {posargs:benchmarks} \
         --durations=0 \
         --benchmark-autosave \
-        --benchmark-histogram \
         --benchmark-only
 
 [testenv:deps]

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,20 @@ commands =
         --benchmark-histogram \
         --benchmark-only
 
+[testenv:deps]
+description =
+    Visualize module dependencies
+deps =
+    pydeps
+changedir = src
+commands =
+    pydeps tensorwaves \
+        -o ../module_structure.svg \
+        --exclude *._* \
+        --max-bacon=1 \
+        --noshow
+passenv = HOME
+
 [testenv:doc]
 description =
     Build documentation and API through Sphinx
@@ -107,20 +121,6 @@ allowlist_externals =
     pytest
 commands =
     pytest --nbmake {posargs:docs}
-
-[testenv:pydeps]
-description =
-    Visualize module dependencies
-deps =
-    pydeps
-changedir = src
-commands =
-    pydeps tensorwaves \
-        -o module_structure.svg \
-        --exclude *._* \
-        --max-bacon=1 \
-        --noshow
-passenv = HOME
 
 [testenv:sty]
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ description =
 allowlist_externals =
     pytest
 commands =
-    pytest src {posargs:tests}
+    pytest {posargs:src tests}
 
 [testenv:bench]
 description =
@@ -37,7 +37,7 @@ description =
 allowlist_externals =
     pytest
 commands =
-    pytest src {posargs:tests} \
+    pytest {posargs:src tests} \
         --cov-fail-under=90 \
         --cov-report=html \
         --cov-report=xml \

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,15 @@ skipsdist = True
 
 [testenv]
 description =
-    Run all unit tests and doctests
+    Run all unit tests and doctests and compute test coverage
 allowlist_externals =
     pytest
 commands =
-    pytest {posargs:src tests}
+    pytest {posargs:src tests} \
+        --cov-fail-under=90 \
+        --cov-report=html \
+        --cov-report=xml \
+        --cov=tensorwaves
 
 [testenv:bench]
 description =
@@ -30,18 +34,6 @@ commands =
         --benchmark-autosave \
         --benchmark-histogram \
         --benchmark-only
-
-[testenv:cov]
-description =
-    Compute test coverage
-allowlist_externals =
-    pytest
-commands =
-    pytest {posargs:src tests} \
-        --cov-fail-under=90 \
-        --cov-report=html \
-        --cov-report=xml \
-        --cov=tensorwaves
 
 [testenv:doc]
 description =


### PR DESCRIPTION
Import expensive modules in the tests inline so that `pytest --collect-only` is faster.