### PR TITLE
feat: implement get_source_code function

### DIFF
--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -242,6 +242,7 @@
     "    expression=expression_1d,\n",
     "    parameters=parameter_defaults,\n",
     "    backend=\"numpy\",\n",
+    "    use_cse=False,\n",
     ")"
    ]
   },
@@ -249,7 +250,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The resulting {class}`.ParametrizedBackendFunction` internally carries some source code that {mod}`numpy` understands. And it indeed looks similar to the expression that we formulated in {ref}`usage/basics:Formulate model`:"
+    ":::{tip}\n",
+    "\n",
+    "<!-- cspell:ignore subexpression -->\n",
+    "Here, we used `use_cse=False` in {func}`.create_parametrized_function`. Setting this argument to `True` (the default) causes {mod}`sympy` to search for common sub-expressions, which speeds up lambdification in large expressions and makes the lambdified source code more efficient. See also {func}`~sympy.simplify.cse_main.cse`.\n",
+    "\n",
+    ":::\n",
+    "\n",
+    "The resulting {class}`.ParametrizedBackendFunction` internally carries some source code that {mod}`numpy` understands. With {func}`.get_source_code`, we can see that it indeed looks similar to the expression that we formulated in {ref}`usage/basics:Formulate model`:"
    ]
   },
   {
@@ -265,14 +273,12 @@
    },
    "outputs": [],
    "source": [
-    "import inspect\n",
-    "\n",
     "from black import FileMode, format_str\n",
     "\n",
-    "src = format_str(\n",
-    "    inspect.getsource(function_1d._ParametrizedBackendFunction__function),\n",
-    "    mode=FileMode(),\n",
-    ")\n",
+    "from tensorwaves.function import get_source_code\n",
+    "\n",
+    "src = get_source_code(function_1d)\n",
+    "src = format_str(src, mode=FileMode())\n",
     "print(src)"
    ]
   },

--- a/docs/usage/step3.ipynb
+++ b/docs/usage/step3.ipynb
@@ -106,7 +106,7 @@
    "source": [
     "To perform a fit, you need to define an {class}`.Estimator`. This is a measure for the discrepancy between the {class}`.ParametrizedFunction` and the data distribution to which you fit it. In PWA, we usually use an **unbinned negative log likelihood estimator** ({class}`.UnbinnedNLL`).\n",
     "\n",
-    "Generally, the {class}`.ParametrizedFunction` is not normalized with regards to the data sample, while a log likelihood estimator requires a normalized function. This is where the {ref}`phase space dataset <usage/step2:2.1 Generate phase space sample>` comes into play again: the {class}`.ParametrizedFunction` is evaluated over the phase space dataset so that its output can be used as a normalization factor.\n",
+    "Generally, the {class}`.ParametrizedFunction` is not normalized with regards to the data sample, while a log likelihood estimator requires a normalized function. This is where the {ref}`phase space data <usage/step2:2.1 Generate phase space sample>` comes into play again: the {class}`.ParametrizedFunction` is evaluated over the phase space data, so that its output can be used as a normalization factor.\n",
     "\n",
     "```{margin}\n",
     "If you want to correct for the efficiency of the detector, you should use a *detector-reconstructed* phase space sample.\n",
@@ -185,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Recall that a {class}`.ParametrizedFunction` object computes the intensity for a certain dataset. This can be seen now nicely when we use these intensities as weights on the phase space sample and plot it together with the original dataset. Here, we look at the invariant mass distribution projection of the final states `1` and `2`, which, {ref}`as we saw before <usage/step2:2.3 Visualize kinematic variables>`, is the final state particle pair $\\pi^0\\pi^0$.\n",
+    "Recall that a {class}`.ParametrizedFunction` object computes the intensity for a certain `.DataSample`. This can be seen now nicely when we use these intensities as weights on the phase space sample and plot it together with the original data sample. Here, we look at the invariant mass distribution projection of the final states `1` and `2`, which, {ref}`as we saw before <usage/step2:2.3 Visualize kinematic variables>`, is the final state particle pair $\\pi^0\\pi^0$.\n",
     "\n",
     "Don't forget to use {meth}`~.ParametrizedFunction.update_parameters` first!"
    ]

--- a/src/tensorwaves/data/__init__.py
+++ b/src/tensorwaves/data/__init__.py
@@ -110,8 +110,8 @@ def _generate_data_bunch(
     phsp_momenta, weights = phsp_generator.generate(
         bunch_size, random_generator
     )
-    dataset = adapter(phsp_momenta)
-    intensities = intensity(dataset)
+    data_momenta = adapter(phsp_momenta)
+    intensities = intensity(data_momenta)
     maxvalue: float = np.max(intensities)
 
     uniform_randoms = random_generator(bunch_size, max_value=maxvalue)

--- a/src/tensorwaves/data/transform.py
+++ b/src/tensorwaves/data/transform.py
@@ -26,11 +26,10 @@ class SympyDataTransformer(DataTransformer):
         """Read-only access to the internal mapping of functions."""
         return dict(self.__functions)
 
-    def __call__(self, dataset: DataSample) -> DataSample:
+    def __call__(self, data: DataSample) -> DataSample:
         """Transform one `.DataSample` into another `.DataSample`."""
         return {
-            key: function(dataset)
-            for key, function in self.__functions.items()
+            key: function(data) for key, function in self.__functions.items()
         }
 
     @classmethod

--- a/src/tensorwaves/estimator.py
+++ b/src/tensorwaves/estimator.py
@@ -45,8 +45,8 @@ class UnbinnedNLL(Estimator):  # pylint: disable=too-many-instance-attributes
     Args:
         function: A `.ParametrizedFunction` that describes a distribution over
             a certain domain.
-        data: The dataset used for the comparison. The model has to be
-            evaluateable with this dataset.
+        data: The `.DataSample` used for the comparison. The function has to be
+            evaluateable with this `.DataSample`.
         phsp: The domain (phase space) over which to execute the function is
             used for the normalization. When correcting for the detector
             efficiency, use a phase space sample that passed the detector

--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -1,7 +1,7 @@
 """Express mathematical expressions in terms of computational functions."""
 
 import inspect
-from typing import Callable, Dict, Iterable, Mapping, Sequence, Tuple
+from typing import Callable, Dict, Iterable, Mapping, Tuple
 
 import attr
 import numpy as np
@@ -89,7 +89,7 @@ class ParametrizedBackendFunction(ParametrizedFunction):
     def __init__(
         self,
         function: Callable[..., np.ndarray],
-        argument_order: Sequence[str],
+        argument_order: Iterable[str],
         parameters: Mapping[str, ParameterValue],
     ) -> None:
         self.__function = function

--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -130,3 +130,15 @@ class ParametrizedBackendFunction(ParametrizedFunction):
                 f" arguments. Expecting one of:{sep}{parameter_listing}"
             )
         self.__parameters.update(new_parameters)
+
+
+def get_source_code(function: Function) -> str:
+    """Get the backend source code used to compile this function."""
+    if isinstance(
+        function, (PositionalArgumentFunction, ParametrizedBackendFunction)
+    ):
+        return inspect.getsource(function.function)
+    raise NotImplementedError(
+        f"Cannot get source code for {Function.__name__} type"
+        f" {type(function).__name__}"
+    )

--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -78,8 +78,8 @@ class PositionalArgumentFunction(Function):
     )
     """Ordered labels for each positional argument."""
 
-    def __call__(self, dataset: DataSample) -> np.ndarray:
-        args = [dataset[var_name] for var_name in self.argument_order]
+    def __call__(self, data: DataSample) -> np.ndarray:
+        args = [data[var_name] for var_name in self.argument_order]
         return self.function(*args)
 
 
@@ -95,9 +95,9 @@ class ParametrizedBackendFunction(ParametrizedFunction):
         self.__function = PositionalArgumentFunction(function, argument_order)
         self.__parameters = dict(parameters)
 
-    def __call__(self, dataset: DataSample) -> np.ndarray:
-        extended_args = {**dataset, **self.__parameters}  # type: ignore[arg-type]
-        return self.__function(extended_args)
+    def __call__(self, data: DataSample) -> np.ndarray:
+        extended_data = {**data, **self.__parameters}  # type: ignore[arg-type]
+        return self.__function(extended_data)
 
     @property
     def function(self) -> Callable[..., np.ndarray]:

--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -92,27 +92,20 @@ class ParametrizedBackendFunction(ParametrizedFunction):
         argument_order: Iterable[str],
         parameters: Mapping[str, ParameterValue],
     ) -> None:
-        self.__function = function
-        self.__argument_order = tuple(argument_order)
+        self.__function = PositionalArgumentFunction(function, argument_order)
         self.__parameters = dict(parameters)
 
     def __call__(self, dataset: DataSample) -> np.ndarray:
-        return self.__function(
-            *[
-                dataset[var_name]
-                if var_name in dataset
-                else self.__parameters[var_name]
-                for var_name in self.__argument_order
-            ],
-        )
+        extended_args = {**dataset, **self.__parameters}  # type: ignore[arg-type]
+        return self.__function(extended_args)
 
     @property
     def function(self) -> Callable[..., np.ndarray]:
-        return self.__function
+        return self.__function.function
 
     @property
     def argument_order(self) -> Tuple[str, ...]:
-        return self.__argument_order
+        return self.__function.argument_order
 
     @property
     def parameters(self) -> Dict[str, ParameterValue]:

--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -107,6 +107,14 @@ class ParametrizedBackendFunction(ParametrizedFunction):
         )
 
     @property
+    def function(self) -> Callable[..., np.ndarray]:
+        return self.__function
+
+    @property
+    def argument_order(self) -> Tuple[str, ...]:
+        return self.__argument_order
+
+    @property
     def parameters(self) -> Dict[str, ParameterValue]:
         return dict(self.__parameters)
 

--- a/src/tensorwaves/function/sympy/__init__.py
+++ b/src/tensorwaves/function/sympy/__init__.py
@@ -192,14 +192,15 @@ def _sympy_lambdify(
 ) -> Callable:
     import sympy as sp
 
-    dummy_replacements = {
-        symbol: sp.Symbol(f"z{i}", **symbol.assumptions0)
-        for i, symbol in enumerate(symbols)
-    }
-    expression = expression.xreplace(dummy_replacements)
-    dummy_symbols = [dummy_replacements[s] for s in symbols]
+    if use_cse:
+        dummy_replacements = {
+            symbol: sp.Symbol(f"z{i}", **symbol.assumptions0)
+            for i, symbol in enumerate(symbols)
+        }
+        expression = expression.xreplace(dummy_replacements)
+        symbols = [dummy_replacements[s] for s in symbols]
     return sp.lambdify(
-        dummy_symbols,
+        symbols,
         expression,
         cse=use_cse,
         modules=modules,

--- a/tests/function/test_function.py
+++ b/tests/function/test_function.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-self-use, redefined-outer-name
+from textwrap import dedent
+
 import numpy as np
 import pytest
 import sympy as sp
@@ -6,6 +8,7 @@ import sympy as sp
 from tensorwaves.function import (
     ParametrizedBackendFunction,
     PositionalArgumentFunction,
+    get_source_code,
 )
 from tensorwaves.function.sympy import create_parametrized_function
 from tensorwaves.interface import DataSample
@@ -89,3 +92,19 @@ class TestPositionalArgumentFunction:
         }
         output = function(data)
         assert pytest.approx(output) == [2, 4, 6]
+
+
+def test_get_source_code():
+    def inline_function(a, x):
+        return a * x
+
+    function = PositionalArgumentFunction(
+        function=inline_function,
+        argument_order=("a", "x"),
+    )
+    src = get_source_code(function)
+    expected_src = """
+        def inline_function(a, x):
+            return a * x
+    """
+    assert dedent(src).strip() == dedent(expected_src).strip()

--- a/tests/function/test_function.py
+++ b/tests/function/test_function.py
@@ -34,6 +34,9 @@ class TestParametrizedBackendFunction:
             expression, parameters, backend="numpy"
         )
 
+    def test_argument_order(self, function: ParametrizedBackendFunction):
+        assert function.argument_order == ("c_1", "c_2", "c_3", "c_4", "x")
+
     @pytest.mark.parametrize(
         ("test_data", "expected_results"),
         [
@@ -54,6 +57,9 @@ class TestParametrizedBackendFunction:
             results, expected_results, decimal=4
         )
 
+    def test_function(self, function: ParametrizedBackendFunction):
+        assert callable(function.function)
+
 
 class TestPositionalArgumentFunction:
     def test_call(self):
@@ -61,6 +67,7 @@ class TestPositionalArgumentFunction:
             function=lambda a, b, x, y: a * x ** 2 + b * y ** 2,
             argument_order=("a", "b", "x", "y"),
         )
+        assert callable(function.function)
         data: DataSample = {
             "a": np.array([1, 0, +1, 1]),
             "b": np.array([1, 0, -1, 1]),
@@ -75,6 +82,7 @@ class TestPositionalArgumentFunction:
             function=lambda *args: args[0] + args[1],
             argument_order=("a", "b"),
         )
+        assert callable(function.function)
         data: DataSample = {
             "a": np.array([1, 2, 3]),
             "b": np.array([1, 2, 3]),

--- a/tests/function/test_function.py
+++ b/tests/function/test_function.py
@@ -15,7 +15,7 @@ class TestParametrizedBackendFunction:
     @pytest.fixture(scope="module")
     def function(self) -> ParametrizedBackendFunction:
         c_1, c_2, c_3, c_4 = sp.symbols("c_(1:5)")
-        x = sp.Symbol("x", complex_twice=True)
+        x = sp.Symbol("x")
         parameters = {
             c_1: 1 + 1j,
             c_2: -1 + 1j,

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -62,7 +62,7 @@ def gaussian_sum(
 
 
 @pytest.fixture(scope="module")
-def phsp_dataset() -> DataSample:
+def phsp() -> DataSample:
     rng = np.random.default_rng(12345)
     return {
         "x": rng.uniform(low=-2.0, high=5.0, size=10000),
@@ -73,7 +73,7 @@ NUMPY_RNG = np.random.default_rng(12345)
 
 
 @pytest.mark.parametrize(
-    ("function", "dataset", "true_params"),
+    ("function", "data", "true_params"),
     [
         (
             gaussian(1.0, 0.1),
@@ -149,14 +149,14 @@ NUMPY_RNG = np.random.default_rng(12345)
 )
 def test_sympy_unbinned_nll(
     function,
-    dataset: DataSample,
+    data: DataSample,
     true_params: Dict[str, ParameterValue],
-    phsp_dataset: DataSample,
+    phsp: DataSample,
 ):
     estimator = UnbinnedNLL(
         function,
-        dataset,
-        phsp_dataset,
+        data,
+        phsp,
         phsp_volume=6.0,
     )
     minuit2 = Minuit2()


### PR DESCRIPTION
Closes #323 

- Added a convenience function `tensorwaves.function.get_source_code()`
- Added read-only properties `function` and `argument_order` to `ParametrizedBackendFunction` (parallels `attrs`-decorated `PositionalArgumentFunction` class).
- `PositionalArgumentFunction` is now used internally in `ParametrizedBackendFunction` (simplifies its `__call__()` method).
- Symbols are not force-dummified anymore if `use_cse=False`