### PR TITLE
build: make ampform an optional dependency

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -27,6 +27,14 @@ This installs the
 you can find on the
 [`stable`](https://github.com/ComPWA/tensorwaves/tree/stable) branch.
 
+Optional dependencies can be installed as follows:
+
+```shell
+pip install tensorwaves[pwa]  # installs tensorwaves with ampform
+pip install tensorwaves[jax,scipy]
+pip install tensorwaves[all]  # all runtime dependencies
+```
+
 The latest version on the
 [`main`](https://github.com/ComPWA/tensorwaves/tree/main) branch can be
 installed as follows:

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ viz =
 all =
     %(jax)s
     %(numba)s
+    %(pwa)s
     %(scipy)s
     %(viz)s
 doc =

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,6 +115,7 @@ flake8 =
     pep8-naming
 mypy =
     %(jax)s
+    %(pwa)s
     %(test-types)s
     mypy >=0.570  # attrs support
     types-docutils

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ python_requires = >=3.6, <3.10
 setup_requires =
     setuptools_scm
 install_requires =
-    ampform ==0.12.*
     attrs >=20.1.0  # https://www.attrs.org/en/stable/api.html#next-gen
     iminuit >=2.0
     numpy
@@ -62,6 +61,8 @@ jax =
     jaxlib
 numba =
     numba
+pwa =
+    ampform ==0.12.*
 scipy =
     scipy >=1
 viz =


### PR DESCRIPTION
AmpForm is not part of the interface and source code implementation anymore and only required when TensorWaves is used for PWA. Install with:

```shell
pip install tensorwaves[pwa]
```