### PR TITLE
build: make tensorflow an optional dependency

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -6,7 +6,7 @@
 #
 absl-py==0.15.0
 alabaster==0.7.12
-ampform==0.12.0
+ampform==0.12.1
 anyio==3.4.0
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==21.3.0
@@ -23,7 +23,7 @@ cachetools==4.2.4
 certifi==2021.10.8
 cffi==1.15.0
 cfgv==3.3.1
-charset-normalizer==2.0.9
+charset-normalizer==2.0.10
 clang==5.0
 click==7.1.2
 cloudpickle==2.0.0
@@ -73,7 +73,7 @@ importlib-metadata==4.2.0
 importlib-resources==3.0.0
 iniconfig==1.1.1
 ipykernel==5.5.6
-ipympl==0.8.4
+ipympl==0.8.5
 ipython==7.16.2
 ipython-genutils==0.2.0
 ipywidgets==7.6.5
@@ -171,7 +171,7 @@ pyzmq==22.3.0
 qrules==0.9.5
 qtconsole==5.2.2
 qtpy==2.0.0
-requests==2.26.0
+requests==2.27.0
 requests-oauthlib==1.3.0
 restructuredtext-lint==1.3.2
 rsa==4.8
@@ -184,7 +184,7 @@ snowballstemmer==2.2.0
 soupsieve==2.3.1
 sphinx==4.3.2
 sphinx-autobuild==2021.3.14
-sphinx-book-theme==0.1.7
+sphinx-book-theme==0.1.8
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.10

--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -63,7 +63,7 @@ graphviz==0.19.1
 greenlet==1.1.2
 grpcio==1.43.0
 h5py==3.1.0
-hepunits==2.1.2
+hepunits==2.1.3
 identify==2.4.1
 idna==3.3
 imagesize==1.3.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -64,7 +64,7 @@ graphviz==0.19.1
 greenlet==1.1.2
 grpcio==1.43.0
 h5py==3.6.0
-hepunits==2.1.2
+hepunits==2.1.3
 identify==2.4.1
 idna==3.3
 imagesize==1.3.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -6,13 +6,13 @@
 #
 absl-py==1.0.0
 alabaster==0.7.12
-ampform==0.12.0
+ampform==0.12.1
 anyio==3.4.0
 aquirdturtle-collapsible-headings==3.1.0
-argcomplete==1.12.3
+argcomplete==2.0.0
 argon2-cffi==21.3.0
 argon2-cffi-bindings==21.2.0
-astroid==2.9.1
+astroid==2.9.2
 astunparse==1.6.3
 attrs==21.4.0
 babel==2.9.1
@@ -25,7 +25,7 @@ cachetools==4.2.4
 certifi==2021.10.8
 cffi==1.15.0
 cfgv==3.3.1
-charset-normalizer==2.0.9
+charset-normalizer==2.0.10
 click==7.1.2
 cloudpickle==2.0.0
 colorama==0.4.4
@@ -72,9 +72,9 @@ iminuit==2.8.4
 importlib-metadata==4.2.0
 importlib-resources==5.4.0
 iniconfig==1.1.1
-ipykernel==6.6.0
-ipympl==0.8.4
-ipython==7.30.1
+ipykernel==6.6.1
+ipympl==0.8.5
+ipython==7.31.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.5
 isort==5.10.1
@@ -119,7 +119,7 @@ myst-nb==0.13.1
 myst-parser==0.15.2
 nbclassic==0.3.4
 nbclient==0.5.9
-nbconvert==6.3.0
+nbconvert==6.4.0
 nbdime==3.1.1
 nbformat==5.1.3
 nbmake==1.1
@@ -178,7 +178,7 @@ pyzmq==22.3.0
 qrules==0.9.5
 qtconsole==5.2.2
 qtpy==2.0.0
-requests==2.26.0
+requests==2.27.0
 requests-oauthlib==1.3.0
 restructuredtext-lint==1.3.2
 rsa==4.8
@@ -191,7 +191,7 @@ snowballstemmer==2.2.0
 soupsieve==2.3.1
 sphinx==4.3.2
 sphinx-autobuild==2021.3.14
-sphinx-book-theme==0.1.7
+sphinx-book-theme==0.1.8
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.10

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -6,12 +6,12 @@
 #
 absl-py==1.0.0
 alabaster==0.7.12
-ampform==0.12.0
+ampform==0.12.1
 anyio==3.4.0
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==21.3.0
 argon2-cffi-bindings==21.2.0
-astroid==2.9.1
+astroid==2.9.2
 astunparse==1.6.3
 attrs==21.4.0
 babel==2.9.1
@@ -23,7 +23,7 @@ cachetools==4.2.4
 certifi==2021.10.8
 cffi==1.15.0
 cfgv==3.3.1
-charset-normalizer==2.0.9
+charset-normalizer==2.0.10
 click==7.1.2
 cloudpickle==2.0.0
 colorama==0.4.4
@@ -71,9 +71,9 @@ iminuit==2.8.4
 importlib-metadata==4.10.0
 importlib-resources==5.4.0
 iniconfig==1.1.1
-ipykernel==6.6.0
-ipympl==0.8.4
-ipython==7.30.1
+ipykernel==6.6.1
+ipympl==0.8.5
+ipython==7.31.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.5
 isort==5.10.1
@@ -118,7 +118,7 @@ myst-nb==0.13.1
 myst-parser==0.15.2
 nbclassic==0.3.4
 nbclient==0.5.9
-nbconvert==6.3.0
+nbconvert==6.4.0
 nbdime==3.1.1
 nbformat==5.1.3
 nbmake==1.1
@@ -177,7 +177,7 @@ pyzmq==22.3.0
 qrules==0.9.5
 qtconsole==5.2.2
 qtpy==2.0.0
-requests==2.26.0
+requests==2.27.0
 requests-oauthlib==1.3.0
 restructuredtext-lint==1.3.2
 rsa==4.8
@@ -190,7 +190,7 @@ snowballstemmer==2.2.0
 soupsieve==2.3.1
 sphinx==4.3.2
 sphinx-autobuild==2021.3.14
-sphinx-book-theme==0.1.7
+sphinx-book-theme==0.1.8
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.10

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -63,7 +63,7 @@ graphviz==0.19.1
 greenlet==1.1.2
 grpcio==1.43.0
 h5py==3.6.0
-hepunits==2.1.2
+hepunits==2.1.3
 identify==2.4.1
 idna==3.3
 imagesize==1.3.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -6,12 +6,12 @@
 #
 absl-py==1.0.0
 alabaster==0.7.12
-ampform==0.12.0
+ampform==0.12.1
 anyio==3.4.0
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==21.3.0
 argon2-cffi-bindings==21.2.0
-astroid==2.9.1
+astroid==2.9.2
 astunparse==1.6.3
 attrs==21.4.0
 babel==2.9.1
@@ -23,7 +23,7 @@ cachetools==4.2.4
 certifi==2021.10.8
 cffi==1.15.0
 cfgv==3.3.1
-charset-normalizer==2.0.9
+charset-normalizer==2.0.10
 click==7.1.2
 cloudpickle==2.0.0
 colorama==0.4.4
@@ -70,9 +70,9 @@ imagesize==1.3.0
 iminuit==2.8.4
 importlib-metadata==4.10.0
 iniconfig==1.1.1
-ipykernel==6.6.0
-ipympl==0.8.4
-ipython==7.30.1
+ipykernel==6.6.1
+ipympl==0.8.5
+ipython==7.31.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.5
 isort==5.10.1
@@ -117,7 +117,7 @@ myst-nb==0.13.1
 myst-parser==0.15.2
 nbclassic==0.3.4
 nbclient==0.5.9
-nbconvert==6.3.0
+nbconvert==6.4.0
 nbdime==3.1.1
 nbformat==5.1.3
 nbmake==1.1
@@ -176,7 +176,7 @@ pyzmq==22.3.0
 qrules==0.9.5
 qtconsole==5.2.2
 qtpy==2.0.0
-requests==2.26.0
+requests==2.27.0
 requests-oauthlib==1.3.0
 restructuredtext-lint==1.3.2
 rsa==4.8
@@ -189,7 +189,7 @@ snowballstemmer==2.2.0
 soupsieve==2.3.1
 sphinx==4.3.2
 sphinx-autobuild==2021.3.14
-sphinx-book-theme==0.1.7
+sphinx-book-theme==0.1.8
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.10

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -63,7 +63,7 @@ graphviz==0.19.1
 greenlet==1.1.2
 grpcio==1.43.0
 h5py==3.6.0
-hepunits==2.1.2
+hepunits==2.1.3
 identify==2.4.1
 idna==3.3
 imagesize==1.3.0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run pytest-benchmark
         run: |
           pytest \
-            --benchmark-only \
+            -k benchmark \
             --benchmark-json output.json \
             --durations=0
         working-directory: benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          pip install -c .constraints/py3.9.txt -e .[test]
+          pip install -c .constraints/py3.9.txt -e .[test,all]
           pip install .
       - name: Run pytest-benchmark
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -c .constraints/py${{ matrix.python-version }}.txt -e .[test]
+          pip install -c .constraints/py${{ matrix.python-version }}.txt -e .[test,all]
           pip install .
       - name: Test with pytest-cov
         run: pytest tests -n auto --cov=tensorwaves --cov-report=xml
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -c .constraints/py${{ matrix.python-version }}.txt -e .[test]
+          pip install -c .constraints/py${{ matrix.python-version }}.txt -e .[test,all]
       - name: Run unit tests and doctests with pytest
         env:
           CUDA_VISIBLE_DEVICES: "-1"
@@ -76,3 +76,20 @@ jobs:
         with:
           name: test_output_${{ matrix.os }}_${{ matrix.python-version }}
           path: tests/output
+
+  pytest-jax:
+    name: Unit tests (JAX only)
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -c .constraints/py3.9.txt -e .[test,jax]
+      - name: Run unit tests and doctests with pytest
+        run: |
+          pytest -k "not (ampform or four_momenta or numba or tensorflow or tf)"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -89,7 +89,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -c .constraints/py3.9.txt -e .[test,jax]
+          pip install -c .constraints/py3.9.txt -e .[test,jax] tox
       - name: Run unit tests and doctests with pytest
-        run: |
-          pytest -k "not (ampform or four_momenta or numba or tensorflow or tf)"
+        run: tox -e jax

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.97
+    rev: 0.0.98
     hooks:
       - id: check-dev-files
         args:

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,12 +12,24 @@ The fastest way of installing this package is through PyPI or Conda:
 python3 -m pip install tensorwaves
 ```
 
+And with support for {doc}`amplitude analysis </amplitude-analysis>`:
+
+```shell
+python3 -m pip install tensorwaves[pwa]
+```
+
 :::
 
 :::{tabbed} Conda
 
 ```shell
 conda install -c conda-forge tensorwaves
+```
+
+And with support for {doc}`amplitude analysis </amplitude-analysis>`:
+
+```shell
+conda install -c conda-forge ampform phasespace
 ```
 
 :::
@@ -31,7 +43,7 @@ Optional dependencies can be installed as follows:
 
 ```shell
 pip install tensorwaves[pwa]  # installs tensorwaves with ampform
-pip install tensorwaves[jax,scipy]
+pip install tensorwaves[jax,scipy,tf]
 pip install tensorwaves[all]  # all runtime dependencies
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,16 +6,26 @@
 
 The fastest way of installing this package is through PyPI or Conda:
 
+:::{margin}
+
+TensorWaves can work with different computational backends. They are provided
+through
+{ref}`optional dependencies <compwa-org:develop:Optional dependencies>`.
+[JAX](https://jax.readthedocs.io) is usually the fastest backend, so it's
+recommended to install that as in the install examples here.
+
+:::
+
 :::{tabbed} PyPI
 
 ```shell
-python3 -m pip install tensorwaves
+python3 -m pip install tensorwaves[jax]
 ```
 
 And with support for {doc}`amplitude analysis </amplitude-analysis>`:
 
 ```shell
-python3 -m pip install tensorwaves[pwa]
+python3 -m pip install tensorwaves[jax,pwa]
 ```
 
 :::
@@ -23,7 +33,7 @@ python3 -m pip install tensorwaves[pwa]
 :::{tabbed} Conda
 
 ```shell
-conda install -c conda-forge tensorwaves
+conda install -c conda-forge tensorwaves jax jaxlib
 ```
 
 And with support for {doc}`amplitude analysis </amplitude-analysis>`:

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,14 +4,14 @@ source = src
 
 [pytest]
 addopts =
-    --benchmark-skip
     --color=yes
     --doctest-continue-on-failure
     --doctest-modules
     --durations=3
+    --ignore-glob=*/.ipynb_checkpoints/*
     --ignore=docs/abbreviate_signature.py
     --ignore=docs/conf.py
-    --ignore-glob=*/.ipynb_checkpoints/*
+    -k "not benchmark"
     -m "not slow"
 filterwarnings =
     error

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,6 @@ test-types =
     pytest
     pytest-mock >=3.3.0
 test =
-    %(all)s
     %(test-types)s
     nbmake
     pytest-benchmark

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,10 +45,8 @@ install_requires =
     attrs >=20.1.0  # https://www.attrs.org/en/stable/api.html#next-gen
     iminuit >=2.0
     numpy
-    phasespace >=1.2.0, <1.5.0  # https://github.com/zfit/phasespace/pull/69
     PyYAML >=5.1  # https://stackoverflow.com/a/55171433
     sympy >=1.9  # lambdify cse
-    tensorflow >=2.4, <2.8  # tensorflow.experimental.numpy
     tqdm >=4.24.0  # autonotebook
 packages = find:
 package_dir =
@@ -60,7 +58,17 @@ jax =
     jaxlib
 numba =
     numba
+tf =
+    tensorflow >=2.4, <2.8  # tensorflow.experimental.numpy
+tensorflow =
+    %(tf)s
+phsp =
+    %(tensorflow)s
+    phasespace >=1.2.0, <1.5.0  # https://github.com/zfit/phasespace/pull/69
+phasespace =
+    %(phsp)s
 pwa =
+    %(phsp)s
     ampform ==0.12.*
 scipy =
     scipy >=1
@@ -71,6 +79,7 @@ all =
     %(numba)s
     %(pwa)s
     %(scipy)s
+    %(tensorflow)s
     %(viz)s
 doc =
     %(all)s

--- a/src/tensorwaves/data/phasespace.py
+++ b/src/tensorwaves/data/phasespace.py
@@ -7,6 +7,7 @@ from typing import Mapping, Tuple
 import numpy as np
 from tqdm.auto import tqdm
 
+from tensorwaves.function._backend import raise_missing_module_error
 from tensorwaves.interface import (
     DataGenerator,
     DataSample,
@@ -90,7 +91,10 @@ class TFWeightedPhaseSpaceGenerator(WeightedDataGenerator):
         initial_state_mass: float,
         final_state_masses: Mapping[int, float],
     ) -> None:
-        import phasespace
+        try:
+            import phasespace
+        except ImportError:  # pragma: no cover
+            raise_missing_module_error("phasespace", extras_require="phsp")
 
         sorted_ids = sorted(final_state_masses)
         self.__phsp_gen = phasespace.nbody_decay(

--- a/src/tensorwaves/data/rng.py
+++ b/src/tensorwaves/data/rng.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 
+from tensorwaves.function._backend import raise_missing_module_error
 from tensorwaves.interface import RealNumberGenerator
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -40,7 +41,10 @@ class TFUniformRealNumberGenerator(RealNumberGenerator):
     """Implements a uniform real random number generator using tensorflow."""
 
     def __init__(self, seed: Optional[float] = None):
-        from tensorflow import float64
+        try:
+            from tensorflow import float64
+        except ImportError:  # pragma: no cover
+            raise_missing_module_error("tensorflow", extras_require="tf")
 
         self.seed = seed
         self.dtype = float64
@@ -70,7 +74,10 @@ def _get_tensorflow_rng(seed: "SeedLike" = None) -> "tf.random.Generator":
 
     https://github.com/zfit/phasespace/blob/5998e2b/phasespace/random.py#L15-L41
     """
-    import tensorflow as tf
+    try:
+        import tensorflow as tf
+    except ImportError:  # pragma: no cover
+        raise_missing_module_error("tensorflow", extras_require="tf")
 
     if seed is None:
         return tf.random.get_global_generator()

--- a/src/tensorwaves/estimator.py
+++ b/src/tensorwaves/estimator.py
@@ -7,7 +7,10 @@ from typing import Callable, Dict, Mapping, Optional
 
 import numpy as np
 
-from tensorwaves.function._backend import find_function
+from tensorwaves.function._backend import (
+    find_function,
+    raise_missing_module_error,
+)
 from tensorwaves.interface import (
     DataSample,
     Estimator,
@@ -22,8 +25,11 @@ def gradient_creator(
 ) -> Callable[[Mapping[str, ParameterValue]], Dict[str, ParameterValue]]:
     # pylint: disable=import-outside-toplevel
     if backend == "jax":
-        import jax
-        from jax.config import config
+        try:
+            import jax
+            from jax.config import config
+        except ImportError:  # pragma: no cover
+            raise_missing_module_error("jax", extras_require="jax")
 
         config.update("jax_enable_x64", True)
 

--- a/src/tensorwaves/function/sympy/__init__.py
+++ b/src/tensorwaves/function/sympy/__init__.py
@@ -21,10 +21,14 @@ from tensorwaves.function import (
     ParametrizedBackendFunction,
     PositionalArgumentFunction,
 )
-from tensorwaves.function._backend import get_backend_modules, jit_compile
+from tensorwaves.function._backend import (
+    get_backend_modules,
+    jit_compile,
+    raise_missing_module_error,
+)
 from tensorwaves.interface import ParameterValue
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import sympy as sp
     from sympy.printing.printer import Printer
 
@@ -142,10 +146,12 @@ def lambdify(
         )
 
     def tensorflow_lambdify() -> Callable:
-        # pylint: disable=import-error
-        # pyright: reportMissingImports=false
-        import tensorflow.experimental.numpy as tnp
-
+        try:
+            # pylint: disable=import-error
+            # pyright: reportMissingImports=false
+            import tensorflow.experimental.numpy as tnp
+        except ImportError:  # pragma: no cover
+            raise_missing_module_error("tensorflow", extras_require="tf")
         from ._printer import TensorflowPrinter
 
         return _sympy_lambdify(

--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -10,6 +10,7 @@ from typing import IO, Any, Dict, Iterable, List, Optional, Type, Union
 import numpy as np
 import yaml
 
+from tensorwaves.function._backend import raise_missing_module_error
 from tensorwaves.interface import Estimator, Optimizer, ParameterValue
 
 
@@ -252,7 +253,10 @@ class TFSummary(Callback):
 
     def on_optimize_start(self, logs: Optional[Dict[str, Any]] = None) -> None:
         # pylint: disable=import-outside-toplevel, no-member
-        import tensorflow as tf
+        try:
+            import tensorflow as tf
+        except ImportError:  # pragma: no cover
+            raise_missing_module_error("tensorflow", extras_require="tf")
 
         output_dir = (
             self.__logdir + "/" + datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -275,7 +279,10 @@ class TFSummary(Callback):
         self, function_call: int, logs: Optional[Dict[str, Any]] = None
     ) -> None:
         # pylint: disable=import-outside-toplevel, no-member
-        import tensorflow as tf
+        try:
+            import tensorflow as tf
+        except ImportError:  # pragma: no cover
+            raise_missing_module_error("tensorflow", extras_require="tf")
 
         if logs is None:
             return

--- a/src/tensorwaves/optimizer/scipy.py
+++ b/src/tensorwaves/optimizer/scipy.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterable, Mapping, Optional
 
 from tqdm.auto import tqdm
 
+from tensorwaves.function._backend import raise_missing_module_error
 from tensorwaves.interface import (
     Estimator,
     FitResult,
@@ -44,7 +45,10 @@ class ScipyMinimizer(Optimizer):
         initial_parameters: Mapping[str, ParameterValue],
     ) -> FitResult:
         # pylint: disable=import-outside-toplevel
-        from scipy.optimize import minimize
+        try:
+            from scipy.optimize import minimize
+        except ImportError:  # pragma: no cover
+            raise_missing_module_error("scipy", extras_require="scipy")
 
         parameter_handler = ParameterFlattener(initial_parameters)
         flattened_parameters = parameter_handler.flatten(initial_parameters)

--- a/tests/data/test_rng.py
+++ b/tests/data/test_rng.py
@@ -1,7 +1,11 @@
-# pylint:disable=no-self-use
+# pylint:disable=no-self-use, import-outside-toplevel
 import pytest
 
-from tensorwaves.data import NumpyUniformRNG, TFUniformRealNumberGenerator
+from tensorwaves.data.rng import (
+    NumpyUniformRNG,
+    TFUniformRealNumberGenerator,
+    _get_tensorflow_rng,
+)
 
 
 class TestNumpyUniformRNG:
@@ -31,3 +35,15 @@ class TestTFUniformRealNumberGenerator:
         generator = TFUniformRealNumberGenerator(seed=456)
         sample = generator(size=3, min_value=-1, max_value=+1)
         assert pytest.approx(sample) == [-0.38057342, -0.21197986, 0.14724727]
+
+
+def test_get_tensorflow_rng():
+    import tensorflow as tf
+
+    for seed in [None, 100, tf.random.Generator.from_seed(seed=0)]:
+        rng = _get_tensorflow_rng(seed)
+        assert isinstance(rng, tf.random.Generator)
+    with pytest.raises(
+        TypeError, match=r"Cannot create a tf\.random\.Generator from a float"
+    ):
+        _get_tensorflow_rng(2.5)

--- a/tests/function/test_backend.py
+++ b/tests/function/test_backend.py
@@ -1,13 +1,18 @@
+# pylint: disable=import-error, import-outside-toplevel
+# pyright: reportMissingImports=false
 from tensorwaves.function._backend import find_function
 
 
-def test_find_function():
-    # pylint: disable=import-error, import-outside-toplevel
-    # pyright: reportMissingImports=false
+def test_find_function_jax():
     import jax.numpy as jnp
+
+    assert find_function("array", backend="jax") is jnp.array
+    assert find_function("linspace", backend="jax") is jnp.linspace
+    assert find_function("mean", backend="jax") is jnp.mean
+
+
+def test_find_function_numpy():
     import numpy as np
-    import tensorflow as tf
-    import tensorflow.experimental.numpy as tnp
 
     assert find_function("array", backend="numpy") is np.array
     assert find_function("linspace", backend="numpy") is np.linspace
@@ -15,9 +20,10 @@ def test_find_function():
     assert find_function("mean", backend="numpy") is np.mean
     assert find_function("mean", backend="numba") is np.mean
 
-    assert find_function("array", backend="jax") is jnp.array
-    assert find_function("linspace", backend="jax") is jnp.linspace
-    assert find_function("mean", backend="jax") is jnp.mean
+
+def test_find_function_tf():
+    import tensorflow as tf
+    import tensorflow.experimental.numpy as tnp
 
     assert find_function("array", backend="tf") is tnp.array
     assert find_function("linspace", backend="tf") is tnp.linspace

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
     pytest {posargs:benchmarks} \
         --durations=0 \
         --benchmark-autosave \
-        --benchmark-only
+        -k benchmark
 
 [testenv:deps]
 description =
@@ -102,6 +102,17 @@ allowlist_externals =
     make
 commands =
     make html
+
+[testenv:jax]
+description =
+    Run tests with JAX only
+allowlist_externals =
+    pytest
+commands =
+    pytest {posargs:src tests} -k "\
+        not (ampform or four_momenta or numba or tensorflow or tf)\
+        and (benchmark or not benchmark)\
+    " --benchmark-disable
 
 [testenv:linkcheck]
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -109,10 +109,10 @@ description =
 allowlist_externals =
     pytest
 commands =
-    pytest {posargs:src tests} -k "\
-        not (ampform or four_momenta or numba or tensorflow or tf)\
-        and (benchmark or not benchmark)\
-    " --benchmark-disable
+    pytest {posargs:} \
+    -k "benchmark or not benchmark" \
+    -k "not (ampform or four_momenta or numba or tensorflow or tf)" \
+    --benchmark-disable
 
 [testenv:linkcheck]
 description =


### PR DESCRIPTION
All computational backends are now optional dependencies (apart from NumPy). So for instance, to install TensorWaves with JAX, run:
```shell
pip install tensorwaves[jax]
```
To do amplitude analysis, install with:
```shell
pip install tensorwaves[jax,pwa]
```