### PR TITLE
fix: hide progress bar of domain generator

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -125,6 +125,7 @@
         "axvline",
         "bdist",
         "cano",
+        "capsys",
         "celltoolbar",
         "cmap",
         "cmin",

--- a/src/tensorwaves/data/_data_sample.py
+++ b/src/tensorwaves/data/_data_sample.py
@@ -56,6 +56,9 @@ def select_events(four_momenta: DataSample, selector: Any) -> DataSample:
 
 
 def finalize_progress_bar(progress_bar: tqdm) -> None:
-    remainder = progress_bar.total - progress_bar.n
+    if progress_bar.total is not None:
+        remainder = progress_bar.total - progress_bar.n
+    else:
+        remainder = 0
     progress_bar.update(n=remainder)  # pylint crashes if total is set directly
     progress_bar.close()

--- a/src/tensorwaves/data/phasespace.py
+++ b/src/tensorwaves/data/phasespace.py
@@ -45,6 +45,8 @@ class TFPhaseSpaceGenerator(DataGenerator):
             initial_state_mass, final_state_masses
         )
         self.__bunch_size = bunch_size
+        # https://github.com/ComPWA/tensorwaves/issues/395
+        self.show_progress = True
 
     def generate(self, size: int, rng: RealNumberGenerator) -> DataSample:
         r"""Generate a `.DataSample` of phase space four-momenta.
@@ -58,7 +60,8 @@ class TFPhaseSpaceGenerator(DataGenerator):
         progress_bar = tqdm(
             total=size,
             desc="Generating phase space sample",
-            disable=logging.getLogger().level > logging.WARNING,
+            disable=not self.show_progress
+            or logging.getLogger().level > logging.WARNING,
         )
         momentum_pool: DataSample = {}
         while get_number_of_events(momentum_pool) < size:


### PR DESCRIPTION
Closes #395 

```python
import ampform
import qrules
from ampform.dynamics.builder import create_relativistic_breit_wigner_with_ff
from tensorwaves.data import (
    IntensityDistributionGenerator,
    TFPhaseSpaceGenerator,
    TFUniformRealNumberGenerator,
)
from tensorwaves.data.transform import SympyDataTransformer
from tensorwaves.function.sympy import create_parametrized_function

reaction = qrules.generate_transitions(
    initial_state="J/psi(1S)",
    final_state=["gamma", "pi0", "pi0"],
    allowed_intermediate_particles=["f(0)"],
    allowed_interaction_types=["strong", "EM"],
)

builder = ampform.get_builder(reaction)
resonances = reaction.get_intermediate_particles()
for p in resonances:
    builder.set_dynamics(p.name, create_relativistic_breit_wigner_with_ff)
model = builder.formulate()

intensity = create_parametrized_function(
    model.expression.doit(),
    parameters=model.parameter_defaults,
    backend="jax",
)
helicity_transformer = SympyDataTransformer.from_sympy(
    model.kinematic_variables, backend="jax"
)

phsp_generator = TFPhaseSpaceGenerator(
    initial_state_mass=reaction.initial_state[-1].mass,
    final_state_masses={i: p.mass for i, p in reaction.final_state.items()},
)
data_generator = IntensityDistributionGenerator(
    function=intensity,
    domain_generator=phsp_generator,
    domain_transformer=helicity_transformer,
)
rng = TFUniformRealNumberGenerator(seed=0)
phsp_momenta = phsp_generator.generate(1_000_000, rng)
data_momenta = data_generator.generate(100_000, rng)
```
![image](https://user-images.githubusercontent.com/29308176/148271814-2c0c19c6-949f-4d58-b2b0-3fd2d7b84337.png)
