### PR TITLE
feat: add minuit_modifier constructor argument

### DIFF
--- a/docs/amplitude-analysis.ipynb
+++ b/docs/amplitude-analysis.ipynb
@@ -1310,7 +1310,7 @@
    "source": [
     ":::{seealso}\n",
     "\n",
-    "Call {meth}`~.Minuit2.setup` first in order to tweak the internal {attr}`~.Minuit2.iminuit` optimizer before calling {meth}`~.Minuit2.optimize`. See {ref}`usage/basics:Minuit2` for how to do this.\n",
+    "See {ref}`usage/basics:Minuit2` for how to tweak the internal {class}`iminuit.Minuit` optimizer.\n",
     "\n",
     ":::\n",
     "\n",

--- a/docs/amplitude-analysis.ipynb
+++ b/docs/amplitude-analysis.ipynb
@@ -1308,6 +1308,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    ":::{seealso}\n",
+    "\n",
+    "Call {meth}`~.Minuit2.setup` first in order to tweak the internal {attr}`~.Minuit2.iminuit` optimizer before calling {meth}`~.Minuit2.optimize`. See {ref}`usage/basics:Minuit2` for how to do this.\n",
+    "\n",
+    ":::\n",
+    "\n",
     "As can be seen, the values of the optimized parameters in the {class}`.FitResult` are again comparable to the original parameter values."
    ]
   },

--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -1070,7 +1070,41 @@
    "outputs": [],
    "source": [
     "estimator = UnbinnedNLL(function_2d, data_2d, domain_2d, backend=\"jax\")\n",
-    "minuit2 = Minuit2(callback=CSVSummary(\"traceback.csv\"))\n",
+    "minuit2 = Minuit2(callback=CSVSummary(\"traceback.csv\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Commonly, one would now just call the {meth}`~.Minuit2.optimize` method of this {class}`.Minuit2` optimizer instance. For more advanced options, one could call also its {meth}`~.Minuit2.setup` method first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "minuit2.setup(estimator, initial_parameters)\n",
+    "minuit2.iminuit.tol = 0.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The modification to {obj}`~iminuit.Minuit.tol` here is just an example. See {class}`iminuit.Minuit` for other options.\n",
+    "\n",
+    "For the rest, the fit procedure goes just as in {ref}`usage:Optimize parameters`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fit_result = minuit2.optimize(estimator, initial_parameters)\n",
     "fit_result"
    ]

--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -1062,6 +1062,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Commonly, one would construct a {class}`.Minuit2` instance and call its {meth}`~.Minuit2.optimize` method. For more advanced options, one could specify a small `minuit_modifier` protocol into the {class}`.Minuit2` constructor. In this example, we set the {attr}`~iminuit.Minuit.tol` attribute. For other options, see {class}`iminuit.Minuit`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tweak_minuit(minuit) -> None:\n",
+    "    minuit.tol = 0.2"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -1070,43 +1087,19 @@
    "outputs": [],
    "source": [
     "estimator = UnbinnedNLL(function_2d, data_2d, domain_2d, backend=\"jax\")\n",
-    "minuit2 = Minuit2(callback=CSVSummary(\"traceback.csv\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Commonly, one would now just call the {meth}`~.Minuit2.optimize` method of this {class}`.Minuit2` optimizer instance. For more advanced options, one could call also its {meth}`~.Minuit2.setup` method first:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "minuit2.setup(estimator, initial_parameters)\n",
-    "minuit2.iminuit.tol = 0.2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The modification to {obj}`~iminuit.Minuit.tol` here is just an example. See {class}`iminuit.Minuit` for other options.\n",
-    "\n",
-    "For the rest, the fit procedure goes just as in {ref}`usage:Optimize parameters`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "minuit2 = Minuit2(\n",
+    "    callback=CSVSummary(\"traceback.csv\"),\n",
+    "    minuit_modifier=tweak_minuit,\n",
+    ")\n",
     "fit_result = minuit2.optimize(estimator, initial_parameters)\n",
     "fit_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the rest, the fit procedure goes just as in {ref}`usage:Optimize parameters`:"
    ]
   },
   {

--- a/src/tensorwaves/optimizer/minuit.py
+++ b/src/tensorwaves/optimizer/minuit.py
@@ -54,6 +54,8 @@ class Minuit2(Optimizer):
         This sets the internal :attr:`iminuit` instance, so that it can be
         tweaked before calling :meth:`optimize`. See `iminuit.Minuit` for more
         info for available methods.
+
+        .. seealso:: Usage is illustrated under :ref:`usage/basics:Minuit2`.
         """
         parameter_handler = ParameterFlattener(initial_parameters)
         flattened_parameters = parameter_handler.flatten(initial_parameters)

--- a/src/tensorwaves/optimizer/minuit.py
+++ b/src/tensorwaves/optimizer/minuit.py
@@ -24,6 +24,10 @@ class Minuit2(Optimizer):
     """Adapter to `Minuit2 <https://root.cern.ch/doc/master/Minuit2Page.html>`_.
 
     Implements the `~.interface.Optimizer` interface using `iminuit.Minuit`.
+    More options can be passed to the internal `~iminuit.Minuit` optimizer by
+    calling :meth:`setup` before :meth:`optimize`. This initializes the
+    :attr:`iminuit` attribute, so that one can pass options to it before
+    calling :meth:`optimize`.
     """
 
     def __init__(
@@ -33,12 +37,24 @@ class Minuit2(Optimizer):
     ) -> None:
         self.__callback = callback
         self.__use_gradient = use_analytic_gradient
+        self.__iminuit: Optional[iminuit.Minuit] = None
 
-    def optimize(  # pylint: disable=too-many-locals
+    @property
+    def iminuit(self) -> Optional[iminuit.Minuit]:
+        """Internal optimizer. Initialize with :meth:`setup`."""
+        return self.__iminuit
+
+    def setup(
         self,
         estimator: Estimator,
         initial_parameters: Mapping[str, ParameterValue],
-    ) -> FitResult:
+    ) -> None:
+        """Initialize internal :attr:`iminuit` optimizer for :meth:`optimize`.
+
+        This sets the internal :attr:`iminuit` instance, so that it can be
+        tweaked before calling :meth:`optimize`. See `iminuit.Minuit` for more
+        info for available methods.
+        """
         parameter_handler = ParameterFlattener(initial_parameters)
         flattened_parameters = parameter_handler.flatten(initial_parameters)
 
@@ -90,38 +106,48 @@ class Minuit2(Optimizer):
             grad = estimator.gradient(parameters)
             return parameter_handler.flatten(grad).values()
 
-        minuit = iminuit.Minuit(
+        self.__iminuit = iminuit.Minuit(
             wrapped_function,
             tuple(flattened_parameters.values()),
             grad=wrapped_gradient if self.__use_gradient else None,
             name=tuple(flattened_parameters),
         )
-        minuit.errors = tuple(
+        self.__iminuit.errors = tuple(
             0.1 * x if x != 0.0 else 0.1 for x in flattened_parameters.values()
         )
-        minuit.errordef = (
+        self.__iminuit.errordef = (
             iminuit.Minuit.LIKELIHOOD
         )  # that error definition should be defined in the estimator
 
+    def optimize(
+        self,
+        estimator: Estimator,
+        initial_parameters: Mapping[str, ParameterValue],
+    ) -> FitResult:
+        if self.iminuit is None:
+            self.setup(estimator, initial_parameters)
+            assert self.iminuit is not None
+
         start_time = time.time()
-        minuit.migrad()
+        self.iminuit.migrad()
         end_time = time.time()
 
         parameter_values = {}
         parameter_errors = {}
-        for i, name in enumerate(flattened_parameters):
-            par_state = minuit.params[i]
+        for i, name in enumerate(self.iminuit.parameters):
+            par_state = self.iminuit.params[i]
             parameter_values[name] = par_state.value
             parameter_errors[name] = par_state.error
 
+        parameter_handler = ParameterFlattener(initial_parameters)
         fit_result = FitResult(
-            minimum_valid=minuit.valid,
+            minimum_valid=self.iminuit.valid,
             execution_time=end_time - start_time,
-            function_calls=minuit.fmin.nfcn,
-            estimator_value=minuit.fmin.fval,
+            function_calls=self.iminuit.fmin.nfcn,
+            estimator_value=self.iminuit.fmin.fval,
             parameter_values=parameter_handler.unflatten(parameter_values),
             parameter_errors=parameter_handler.unflatten(parameter_errors),
-            specifics=minuit,
+            specifics=self.iminuit,
         )
 
         if self.__callback is not None:


### PR DESCRIPTION
This makes it possible to access [`iminuit.Minuit`](https://iminuit.readthedocs.io/en/stable/reference.html#iminuit.Minuit)'s methods and attributes before calling `optimize()`.