### PR TITLE
docs: illustrate Hesse from FitResult.specifics

### DIFF
--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -1088,6 +1088,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the rest, the fit procedure goes just as in {ref}`usage:Optimize parameters`:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -1108,7 +1115,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the rest, the fit procedure goes just as in {ref}`usage:Optimize parameters`:"
+    "Note that further information about the internal {class}`iminuit.Minuit` optimizer is available through {attr}`.FitResult.specifics`, e.g. computing the {meth}`~iminuit.Minuit.hesse` afterwards:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit_result.specifics.hesse()"
    ]
   },
   {

--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -148,6 +148,8 @@ class CSVSummary(Callback, Loadable):
             self.__latest_iteration = None
             self.__write(logs)
         _close_stream(self.__stream)
+        self.__stream = None
+        self.__writer = None
 
     def on_iteration_end(
         self, iteration: int, logs: Optional[Dict[str, Any]] = None
@@ -178,9 +180,7 @@ class CSVSummary(Callback, Loadable):
 
     def __write(self, logs: Dict[str, Any]) -> None:
         if self.__writer is None:
-            raise ValueError(
-                f"{csv.DictWriter.__name__} has not been initialized"
-            )
+            return
         row_dict = self.__log_to_rowdict(logs)
         self.__writer.writerow(row_dict)
 
@@ -328,6 +328,7 @@ class YAMLSummary(Callback, Loadable):
             return
         self.__dump_to_yaml(logs)
         _close_stream(self.__stream)
+        self.__stream = None
 
     def on_iteration_end(
         self, iteration: int, logs: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
Also fixes a small bug: callbacks that write to disk skip writing when computing the Hesse.

Preview [here](https://tensorwaves--401.org.readthedocs.build/en/401/usage/basics.html#minuit2).