### PR TITLE
fix: use xreplace in prepare_caching()

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -126,6 +126,7 @@
         "axhline",
         "axvline",
         "bdist",
+        "bgcolor",
         "cano",
         "capsys",
         "celltoolbar",

--- a/docs/amplitude-analysis.ipynb
+++ b/docs/amplitude-analysis.ipynb
@@ -1087,7 +1087,9 @@
    },
    "outputs": [],
    "source": [
-    "dot = sp.dotprint(expression.args[0].args[0].args[0].args[0], size=12)\n",
+    "dot = sp.dotprint(\n",
+    "    expression.args[0].args[0].args[0].args[0], size=12, bgcolor=\"none\"\n",
+    ")\n",
     "graphviz.Source(dot)"
    ]
   },
@@ -1112,7 +1114,9 @@
    "outputs": [],
    "source": [
     "dot = sp.dotprint(\n",
-    "    optimized_expression.args[0].args[0].args[0].args[0], size=12\n",
+    "    optimized_expression.args[0].args[0].args[0].args[0],\n",
+    "    size=12,\n",
+    "    bgcolor=\"none\",\n",
     ")\n",
     "graphviz.Source(dot)"
    ]

--- a/docs/usage/caching.ipynb
+++ b/docs/usage/caching.ipynb
@@ -185,6 +185,7 @@
     "        substitute_identifiable_symbols(expression, symbols=free_symbols),\n",
     "        styles=dot_style,\n",
     "        dpi=60,\n",
+    "        bgcolor=\"none\",\n",
     "    )\n",
     "    graph = graphviz.Source(dot)\n",
     "    display(graph)\n",
@@ -263,7 +264,7 @@
    "source": [
     "visualize_free_symbols(top_expression, free_symbols)\n",
     "for symbol, expr in sub_expressions.items():\n",
-    "    dot = sp.dotprint(expr, dpi=60, styles=dot_style)\n",
+    "    dot = sp.dotprint(expr, dpi=60, styles=dot_style, bgcolor=\"none\")\n",
     "    display(graphviz.Source(dot))"
    ]
   },
@@ -322,7 +323,7 @@
     "for symbol, expr in transformer_expressions.items():\n",
     "    if expr is symbol:\n",
     "        continue\n",
-    "    dot = sp.dotprint(expr, dpi=60, styles=dot_style)\n",
+    "    dot = sp.dotprint(expr, dpi=60, styles=dot_style, bgcolor=\"none\")\n",
     "    display(graphviz.Source(dot))"
    ]
   },

--- a/docs/usage/faster-lambdify.ipynb
+++ b/docs/usage/faster-lambdify.ipynb
@@ -144,7 +144,7 @@
    },
    "outputs": [],
    "source": [
-    "dot = sp.dotprint(expr)\n",
+    "dot = sp.dotprint(expr, bgcolor=\"none\")\n",
     "graphviz.Source(dot)"
    ]
   },
@@ -210,7 +210,7 @@
    },
    "outputs": [],
    "source": [
-    "dot = sp.dotprint(top_expr)\n",
+    "dot = sp.dotprint(top_expr, bgcolor=\"none\")\n",
     "graphviz.Source(dot)"
    ]
   },
@@ -228,7 +228,7 @@
    "outputs": [],
    "source": [
     "for symbol, definition in sub_expressions.items():\n",
-    "    dot = sp.dotprint(definition)\n",
+    "    dot = sp.dotprint(definition, bgcolor=\"none\")\n",
     "    graph = graphviz.Source(dot)\n",
     "    graph.render(filename=f\"sub_expr_{symbol.name}\", format=\"svg\")\n",
     "\n",

--- a/src/tensorwaves/estimator.py
+++ b/src/tensorwaves/estimator.py
@@ -81,7 +81,7 @@ def create_cached_function(
         cache_expression, free_parameter_values, backend, use_cse=use_cse
     )
     cache_transformer = SympyDataTransformer.from_sympy(
-        transformer_expressions, backend
+        transformer_expressions, backend, use_cse=use_cse
     )
     return cached_function, cache_transformer
 

--- a/src/tensorwaves/estimator.py
+++ b/src/tensorwaves/estimator.py
@@ -48,6 +48,17 @@ def create_cached_function(
     Once it is known which parameters in an expression are to be optimized,
     this function makes it easy to cache constant sub-trees.
 
+    Args:
+        expression: The `~sympy.core.expr.Expr` that should be expressed in a
+            computational backend.
+        parameters: Symbols in the :code:`expression` that should be
+            interpreted as parameters. The values in this mapping will be used
+            in the returned :attr:`.ParametrizedFunction.parameters`.
+        backend: The computational backend to which in which to express the
+            input :code:`expression`.
+
+        use_cse: See :func:`.create_parametrized_function`.
+
     Returns:
         A 'cached' `.ParametrizedFunction` with only the free
         `~.ParametrizedFunction.parameters` that are to be optimized and a

--- a/src/tensorwaves/function/sympy/__init__.py
+++ b/src/tensorwaves/function/sympy/__init__.py
@@ -313,6 +313,8 @@ def extract_constant_sub_expressions(
             sub-expressions. Setting this to `True` makes the order
             deterministic, but this is slower, because requires lambdifying
             each sub-expression to `str` first.
+
+    .. seealso:: :ref:`usage/caching:Extract constant sub-expressions`
     """
     import sympy as sp
 
@@ -386,6 +388,8 @@ def prepare_caching(
             sub-expressions. Setting this to `True` makes the order
             deterministic, but this is slower, because requires lambdifying
             each sub-expression to `str` first.
+
+    .. seealso:: :ref:`usage/caching:Extract constant sub-expressions`
     """
     free_parameter_values = {}
     fixed_parameter_values = {}

--- a/src/tensorwaves/function/sympy/__init__.py
+++ b/src/tensorwaves/function/sympy/__init__.py
@@ -377,7 +377,7 @@ def prepare_caching(
         parameters: A mapping of values for each of the parameter symbols in
             the :code:`expression`. Parameters that are not
             :code:`free_parameters` are substituted in the returned expressions
-            with :meth:`~sympy.core.basic.Basic.subs`.
+            with :meth:`~sympy.core.basic.Basic.xreplace`.
         free_parameters: `~sympy.core.symbol.Symbol` instances in the main
             :code:`expression` that are to be considered parameters and that
             will be optimized by an `.Optimizer` later on.
@@ -394,7 +394,7 @@ def prepare_caching(
             free_parameter_values[par] = value
         else:
             fixed_parameter_values[par] = value
-    expression = expression.subs(fixed_parameter_values)
+    expression = expression.xreplace(fixed_parameter_values)
 
     cache_expression, sub_expressions = extract_constant_sub_expressions(
         expression, free_parameters, fix_order


### PR DESCRIPTION
Previously, [`prepare_caching()`](https://tensorwaves.readthedocs.io/en/0.4.1/api/tensorwaves.function.sympy.html#tensorwaves.function.sympy.prepare_caching) (which is used by [`create_cached_function()`](https://tensorwaves.readthedocs.io/en/0.4.1/api/tensorwaves.function.sympy.html#tensorwaves.estimator.create_cached_function)) substituted fixed parameter values with [`subs()`](https://docs.sympy.org/latest/modules/core.html#sympy.core.basic.Basic.subs), which can be slow in case of larger expressions. The function now uses [`xreplace()`](https://docs.sympy.org/latest/modules/core.html#sympy.core.basic.Basic.xreplace) instead.

Also improved the docstrings of both functions, preview [here](https://tensorwaves--403.org.readthedocs.build/en/403/api/tensorwaves.estimator.html#tensorwaves.estimator.create_cached_function).