### PR TITLE
docs: show second level in left sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -246,6 +246,7 @@ intersphinx_mapping = {
         None,
     ),
     "compwa-org": ("https://compwa-org.readthedocs.io", None),
+    "graphviz": ("https://graphviz.readthedocs.io/en/stable", None),
     "iminuit": ("https://iminuit.readthedocs.io/en/stable", None),
     "jax": ("https://jax.readthedocs.io/en/latest", None),
     "matplotlib": (

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,6 +166,7 @@ html_theme_options = {
         "thebe": True,
         "thebelab": True,
     },
+    "show_navbar_depth": 2,
     "theme_dev_mode": True,
 }
 html_title = "TensorWaves"


### PR DESCRIPTION
Links to `graphviz`'s API are now also embedded correctly. Follow-up to #405.