### PR TITLE
ci: manually run tests with latest AmpForm version

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -105,3 +105,22 @@ jobs:
         run: pip install git+https://github.com/ComPWA/ampform@main
       - name: Run unit tests and doctests with pytest
         run: tox -e jax
+
+  pytest-notebook:
+    name: Run all notebooks
+    if: ${{ github.event.inputs.latest-ampform-version }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -c .constraints/py3.8.txt -e .[doc,test] tox
+      - name: Install latest version of AmpForm
+        run: pip install git+https://github.com/ComPWA/ampform@main
+      - name: Run all notebooks with pytest
+        run: tox -e nb

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -28,9 +28,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -c .constraints/py${{ matrix.python-version }}.txt -e .[test,all]
-          pip install .
       - name: Test with pytest-cov
-        run: pytest tests -n auto --cov=tensorwaves --cov-report=xml
+        run: pytest --cov=tensorwaves --cov-report=xml
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
       - epic/*
+  workflow_dispatch:
+    latest-ampform-version:
+      description: Test against latest version of AmpForm
+      required: false
+      type: boolean
 
 jobs:
   codecov:
@@ -28,6 +33,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -c .constraints/py${{ matrix.python-version }}.txt -e .[test,all]
+      - name: Install latest version of AmpForm
+        if: ${{ github.event.inputs.latest-ampform-version }}
+        run: pip install git+https://github.com/ComPWA/ampform@main
       - name: Test with pytest-cov
         run: pytest --cov=tensorwaves --cov-report=xml
       - uses: actions/upload-artifact@v2
@@ -66,6 +74,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -c .constraints/py${{ matrix.python-version }}.txt -e .[test,all]
+      - name: Install latest version of AmpForm
+        if: ${{ github.event.inputs.latest-ampform-version }}
+        run: pip install git+https://github.com/ComPWA/ampform@main
       - name: Run unit tests and doctests with pytest
         env:
           CUDA_VISIBLE_DEVICES: "-1"
@@ -89,5 +100,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -c .constraints/py3.9.txt -e .[test,jax] tox
+      - name: Install latest version of AmpForm
+        if: ${{ github.event.inputs.latest-ampform-version }}
+        run: pip install git+https://github.com/ComPWA/ampform@main
       - name: Run unit tests and doctests with pytest
         run: tox -e jax

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,6 +191,7 @@ nitpick_ignore = [
 # Intersphinx settings
 version_remapping = {
     "matplotlib": {"3.5.1": "3.5.0"},
+    "scipy": {"1.7.3": "1.7.1"},
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,6 +168,7 @@ html_theme_options = {
         "thebelab": True,
     },
     "show_navbar_depth": 2,
+    "show_toc_level": 2,
     "theme_dev_mode": True,
 }
 html_title = "TensorWaves"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -234,7 +234,7 @@ def get_minor_version(package_name: str) -> str:
 
 
 __SCIPY_URL = f"https://docs.scipy.org/doc/scipy-{get_version('scipy')}"
-r = requests.get(__SCIPY_URL + "/tf")
+r = requests.get(__SCIPY_URL)
 if r.status_code == 404:
     __SCIPY_URL = "https://docs.scipy.org/doc/scipy/reference"
 


### PR DESCRIPTION
Adds a [`workflow_dispatch` with inputs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs) that allows running all tests manually with the latest version of AmpForm installed.