### PR TITLE
docs: use create_cached_function() in PWA notebook

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -169,6 +169,7 @@
         "ipykernel",
         "isinstance",
         "isort",
+        "isrealobj",
         "jupyterlab",
         "keras",
         "kernelspec",

--- a/docs/amplitude-analysis.ipynb
+++ b/docs/amplitude-analysis.ipynb
@@ -446,8 +446,9 @@
    "source": [
     "from tensorwaves.function.sympy import create_parametrized_function\n",
     "\n",
+    "unfolded_expression = model.expression.doit()\n",
     "intensity = create_parametrized_function(\n",
-    "    expression=model.expression.doit(),\n",
+    "    expression=unfolded_expression,\n",
     "    parameters=model.parameter_defaults,\n",
     "    max_complexity=200,\n",
     "    backend=\"numpy\",\n",
@@ -896,8 +897,7 @@
    "source": [
     "import sympy as sp\n",
     "\n",
-    "expression = model.expression.doit()\n",
-    "sp.count_ops(expression)"
+    "sp.count_ops(unfolded_expression)"
    ]
   },
   {
@@ -914,7 +914,7 @@
     "    for p, v in model.parameter_defaults.items()\n",
     "    if p not in free_parameters\n",
     "}\n",
-    "optimized_expression = expression.subs(fixed_parameters)\n",
+    "optimized_expression = unfolded_expression.subs(fixed_parameters)\n",
     "sp.count_ops(optimized_expression)"
    ]
   },
@@ -1146,7 +1146,9 @@
    "outputs": [],
    "source": [
     "dot = sp.dotprint(\n",
-    "    expression.args[0].args[0].args[0].args[0], size=12, bgcolor=\"none\"\n",
+    "    unfolded_expression.args[0].args[0].args[0].args[0],\n",
+    "    size=12,\n",
+    "    bgcolor=\"none\",\n",
     ")\n",
     "graphviz.Source(dot)"
    ]
@@ -1657,7 +1659,7 @@
    "outputs": [],
    "source": [
     "parameter_substitutions = model.parameter_defaults\n",
-    "for symbol in expression.free_symbols:\n",
+    "for symbol in unfolded_expression.free_symbols:\n",
     "    optimized_value = fit_result.parameter_values.get(symbol.name)\n",
     "    if optimized_value is not None:\n",
     "        parameter_substitutions[symbol] = optimized_value"

--- a/docs/amplitude-analysis.ipynb
+++ b/docs/amplitude-analysis.ipynb
@@ -1205,7 +1205,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
    "outputs": [],
    "source": [
     "assert len(free_parameter_symbols) == len(initial_parameters)"
@@ -1255,10 +1262,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# JIT-compile functions and test equality\n",
     "np.testing.assert_array_almost_equal(\n",
-    "    intensity(data_real),\n",
     "    cached_function(cached_data),\n",
+    "    intensity(data_real),\n",
     "    decimal=13,\n",
     ")"
    ]

--- a/docs/amplitude-analysis.ipynb
+++ b/docs/amplitude-analysis.ipynb
@@ -830,6 +830,31 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "parameter_names = {symbol.name for symbol in model.parameter_defaults}\n",
+    "not_in_model = {\n",
+    "    par_name\n",
+    "    for par_name in initial_parameters\n",
+    "    if par_name not in parameter_names\n",
+    "}\n",
+    "if len(not_in_model) != 0:\n",
+    "    raise ValueError(\n",
+    "        f\"Parameters {', '.join(sorted(not_in_model))} do not exist in model\"\n",
+    "    )"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/amplitude-analysis.ipynb
+++ b/docs/amplitude-analysis.ipynb
@@ -1020,13 +1020,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tensorwaves.interface import DataSample\n",
+    "\n",
+    "\n",
+    "def safe_downcast_to_real(data: DataSample) -> DataSample:\n",
+    "    # using isrealobj instead of real_if_close to keep same array backend\n",
+    "    return {\n",
+    "        key: array.real if np.isrealobj(array) else array\n",
+    "        for key, array in data.items()\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "data_real = {var: array.real for var, array in data.items()}\n",
-    "phsp_real = {var: array.real for var, array in phsp.items()}"
+    "data_real = safe_downcast_to_real(data)\n",
+    "phsp_real = safe_downcast_to_real(phsp)"
    ]
   },
   {

--- a/docs/amplitude-analysis.ipynb
+++ b/docs/amplitude-analysis.ipynb
@@ -791,7 +791,7 @@
     "\n",
     ":::{tip}\n",
     "\n",
-    "The sections below illustrate some tricks for how to simplify the tree underneath a {class}`.ParametrizedFunction`. **Most of this can also be achieved with {func}`.create_cached_function`**, which is illustrated in {doc}`/usage/caching`. But note that it is still smart to {ref}`cast complex-valued data <amplitude-analysis:Cast complex-valued data>`.\n",
+    "The sections below illustrate some tricks for how to simplify the expression tree underneath a {class}`.ParametrizedFunction`. **Most of this can also be achieved with {func}`.create_cached_function`**, which is illustrated in {doc}`/usage/caching` and under {ref}`compwa-create_cached_function`. But note that it is still smart to {ref}`cast complex-valued data <amplitude-analysis:Cast complex-valued data>`.\n",
     "\n",
     ":::"
    ]
@@ -1077,7 +1077,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note how much faster than the original expression that was created in {ref}`amplitude-analysis:2.2 Generate intensity-based sample`!"
+    "Note that the intensities computed by the optimized function are indeed the same as the original intensity function that was created in {ref}`amplitude-analysis:2.2 Generate intensity-based sample` and that it is much faster!"
    ]
   },
   {
@@ -1175,6 +1175,112 @@
     "    bgcolor=\"none\",\n",
     ")\n",
     "graphviz.Source(dot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(compwa-create_cached_function)=\n",
+    "#### Simplified procedure: {func}`.create_cached_function`\n",
+    "\n",
+    "As noted under {ref}`amplitude-analysis:3.1 Prepare parametrized function`, most of what is described in this section can be achieved with the function {func}`.create_cached_function`. The idea is described on {doc}`/usage/caching`, but in this section, we show how this translates to amplitude analysis.\n",
+    "\n",
+    "First, note that {func}`.create_cached_function` works with mappings and iterable of {class}`sympy.Symbol <sympy.core.symbol.Symbol>` and not with the {obj}`str` mappings that we defined in {ref}`amplitude-analysis:Determine free parameters`. We can convert the parameter names back to {class}`~sympy.core.symbol.Symbol`s as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "free_parameter_symbols = [\n",
+    "    symbol\n",
+    "    for symbol in model.parameter_defaults\n",
+    "    if symbol.name in set(initial_parameters)\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert len(free_parameter_symbols) == len(initial_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This gives us all the information we need to create a cached function, convert the data samples to cached data samples and construct an {class}`.Estimator` with these transformed items (compare {ref}`amplitude-analysis:3.2 Define estimator`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tensorwaves.estimator import UnbinnedNLL, create_cached_function\n",
+    "\n",
+    "cached_function, cache_transformer = create_cached_function(\n",
+    "    unfolded_expression,\n",
+    "    parameters=model.parameter_defaults,\n",
+    "    free_parameters=free_parameter_symbols,\n",
+    "    backend=\"jax\",\n",
+    ")\n",
+    "cached_data = cache_transformer(data_real)\n",
+    "cached_phsp = cache_transformer(phsp_real)\n",
+    "estimator_with_caching = UnbinnedNLL(\n",
+    "    cached_function,\n",
+    "    data=cached_data,\n",
+    "    phsp=cached_phsp,\n",
+    "    backend=\"jax\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that, just like in {ref}`amplitude-analysis:Create computational function`, the computed intensities of both the original intensity function and the cached function are indeed the same:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# JIT-compile functions and test equality\n",
+    "np.testing.assert_array_almost_equal(\n",
+    "    intensity(data_real),\n",
+    "    cached_function(cached_data),\n",
+    "    decimal=13,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{autolink-skip}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%timeit -n1 intensity(data_real)\n",
+    "%timeit -n1 cached_function(cached_data)"
    ]
   },
   {

--- a/docs/amplitude-analysis.ipynb
+++ b/docs/amplitude-analysis.ipynb
@@ -1083,19 +1083,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
-    "tags": [
-     "remove-cell"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# JIT-compile functions\n",
-    "function_output = optimized_function(data_real)\n",
-    "function_output = intensity(data_real)"
+    "# JIT-compile functions and test equality\n",
+    "np.testing.assert_array_almost_equal(\n",
+    "    optimized_function(data_real),\n",
+    "    intensity(data_real),\n",
+    "    decimal=13,\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
Added an example of how to use [`create_cached_function()`](https://tensorwaves--412.org.readthedocs.build/en/412/api/tensorwaves.estimator.html#tensorwaves.estimator.create_cached_function) in combination with an [`Estimator`](https://tensorwaves--412.org.readthedocs.build/en/412/api/tensorwaves.estimator.html#tensorwaves.estimator.Estimator). Preview [here](https://tensorwaves--412.org.readthedocs.build/en/412/amplitude-analysis.html#simplified-procedure-create-cached-function).