### PR TITLE
docs: show how to install from git with opt. deps

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -139,11 +139,17 @@ if you run into trouble.
 ::::
 
 The latest version on the
-[`main`](https://github.com/ComPWA/tensorwaves/tree/main) branch can be
-installed as follows:
+[`main`](https://github.com/ComPWA/tensorwaves/tree/main) branch (or any other
+branch, tag, or commit) can be installed as follows:
 
 ```shell
 python3 -m pip install git+https://github.com/ComPWA/tensorwaves@main
+```
+
+Or, with optional dependencies:
+
+```shell
+python3 -m pip install "tensorwaves[jax,pwa] @ git+https://github.com/ComPWA/tensorwaves@main"
 ```
 
 ## Editable installation


### PR DESCRIPTION
Added an additional install example that shows how to install a specific branch or tag with `pip` from Git _with optional dependencies_. Preview [here](https://tensorwaves--413.org.readthedocs.build/en/413/install.html#quick-installation).