### PR TITLE
fix: compute default weights from observed values

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,6 @@ html_theme_options = {
     },
     "show_navbar_depth": 2,
     "show_toc_level": 2,
-    "theme_dev_mode": True,
 }
 html_title = "TensorWaves"
 panels_add_bootstrap_css = False  # wider page width with sphinx-panels

--- a/src/tensorwaves/estimator.py
+++ b/src/tensorwaves/estimator.py
@@ -150,7 +150,7 @@ class ChiSquared(Estimator):
         self.__observed_values = observed_values
         if weights is None:
             ones = find_function("ones", backend)
-            self.__weights = ones(len(self.__domain))
+            self.__weights = ones(len(self.__observed_values))
         else:
             self.__weights = weights
 


### PR DESCRIPTION
If feeding a `DataSample` as `domain` without weights, the size of the array previously became equal to the number of keys in the `DataSample`, whereas it should be the `len` of each of its arrays. This PR fixes that bug by computing the size from the `observed_y`, which is one-dimensional anyway.