### PR TITLE
build: allow installing AmpForm v0.14.x

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -25,7 +25,6 @@ cffi==1.15.0
 cfgv==3.3.1
 charset-normalizer==2.0.12
 clang==5.0
-click==8.0.4
 cloudpickle==2.0.0
 colorama==0.4.4
 contextvars==2.4
@@ -128,13 +127,11 @@ pandas==1.1.5
 pandocfilters==1.5.0
 parso==0.7.1
 particle==0.20.1
-pep517==0.12.0
 pep8-naming==0.12.1
 pexpect==4.8.0
 phasespace==1.4.2
 pickleshare==0.7.5
 pillow==8.4.0
-pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
 pre-commit==2.17.0
@@ -233,5 +230,4 @@ wrapt==1.12.1
 zipp==3.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools

--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -16,7 +16,7 @@ async-generator==1.10
 attrs==21.4.0
 babel==2.9.1
 backcall==0.2.0
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.0
 bleach==4.1.0
 cached-property==1.5.2
 cachetools==4.2.4

--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -138,8 +138,8 @@ pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
 pre-commit==2.17.0
-prometheus-client==0.13.1
-prompt-toolkit==3.0.28
+prometheus-client==0.14.0
+prompt-toolkit==3.0.29
 protobuf==3.19.4
 ptyprocess==0.7.0
 py==1.11.0
@@ -180,7 +180,7 @@ six==1.15.0
 smmap==5.0.0
 sniffio==1.2.0
 snowballstemmer==2.2.0
-soupsieve==2.3.1
+soupsieve==2.3.2
 sphinx==4.3.2 ; python_version < "3.8.0"
 sphinx-autobuild==2021.3.14
 sphinx-book-theme==0.2.0
@@ -197,7 +197,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphobjinv==2.2.2
-sqlalchemy==1.4.34
+sqlalchemy==1.4.35
 sympy==1.9
 tensorboard==2.6.0
 tensorboard-data-server==0.6.1
@@ -218,7 +218,7 @@ types-docutils==0.18.0
 types-pkg-resources==0.1.3
 types-pyyaml==6.0.5
 types-requests==2.27.16
-types-setuptools==57.4.11
+types-setuptools==57.4.12
 types-urllib3==1.26.11
 typing-extensions==3.7.4.3
 urllib3==1.26.9

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -16,7 +16,7 @@ astunparse==1.6.3
 attrs==21.4.0
 babel==2.9.1
 backcall==0.2.0
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.0
 black==22.3.0 ; python_version >= "3.7.0"
 bleach==5.0.0
 cached-property==1.5.2
@@ -95,7 +95,7 @@ jupyterlab==3.3.3
 jupyterlab-code-formatter==1.4.10
 jupyterlab-markup==1.0.1
 jupyterlab-myst==0.1.6 ; python_version >= "3.7.0"
-jupyterlab-pygments==0.1.2
+jupyterlab-pygments==0.2.0
 jupyterlab-server==2.12.0
 jupyterlab-widgets==1.1.0
 keras==2.7.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -138,13 +138,11 @@ pandocfilters==1.5.0
 parso==0.8.3
 particle==0.20.1
 pathspec==0.9.0
-pep517==0.12.0
 pep8-naming==0.12.1
 pexpect==4.8.0
 phasespace==1.4.2
 pickleshare==0.7.5
 pillow==9.1.0
-pip-tools==6.6.0
 platformdirs==2.5.1
 pluggy==1.0.0
 pre-commit==2.18.1
@@ -247,5 +245,4 @@ wrapt==1.14.0
 zipp==3.8.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -56,7 +56,7 @@ fonttools==4.31.2
 gast==0.4.0
 gitdb==4.0.9
 gitpython==3.1.27
-google-auth==2.6.2
+google-auth==2.6.3
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.19.1
@@ -77,8 +77,8 @@ ipython==7.32.0
 ipython-genutils==0.2.0
 ipywidgets==7.7.0
 isort==5.10.1
-jax==0.3.4
-jaxlib==0.3.2
+jax==0.3.5
+jaxlib==0.3.5
 jedi==0.18.1
 jinja2==3.1.1
 json5==0.9.6

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -6,7 +6,7 @@
 #
 absl-py==1.0.0
 alabaster==0.7.12
-ampform==0.13.3
+ampform==0.14.0
 anyio==3.5.0
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==21.3.0
@@ -18,7 +18,7 @@ babel==2.9.1
 backcall==0.2.0
 beautifulsoup4==4.10.0
 black==22.3.0 ; python_version >= "3.7.0"
-bleach==4.1.0
+bleach==5.0.0
 cached-property==1.5.2
 cachetools==5.0.0
 certifi==2021.10.8
@@ -39,6 +39,7 @@ dm-tree==0.1.6
 docutils==0.17.1
 entrypoints==0.4
 execnet==1.9.0
+fastjsonschema==2.15.3
 filelock==3.6.0
 flake8==4.0.1
 flake8-blind-except==0.2.1
@@ -70,7 +71,7 @@ iminuit==2.11.2
 importlib-metadata==4.2.0
 importlib-resources==5.6.0
 iniconfig==1.1.1
-ipykernel==6.11.0
+ipykernel==6.12.1
 ipympl==0.8.8
 ipython==7.32.0
 ipython-genutils==0.2.0
@@ -84,13 +85,13 @@ json5==0.9.6
 jsonschema==4.4.0
 jupyter==1.0.0
 jupyter-cache==0.4.3
-jupyter-client==7.2.1
+jupyter-client==7.2.2
 jupyter-console==6.4.3
 jupyter-core==4.9.2
 jupyter-server==1.16.0
 jupyter-server-mathjax==0.2.5
 jupyter-sphinx==0.3.2
-jupyterlab==3.3.2
+jupyterlab==3.3.3
 jupyterlab-code-formatter==1.4.10
 jupyterlab-markup==1.0.1
 jupyterlab-myst==0.1.6 ; python_version >= "3.7.0"
@@ -121,7 +122,7 @@ nbclassic==0.3.7
 nbclient==0.5.13
 nbconvert==6.4.5
 nbdime==3.1.1
-nbformat==5.2.0
+nbformat==5.3.0
 nbmake==1.3.0
 nest-asyncio==1.5.5
 nodeenv==1.6.0
@@ -143,12 +144,12 @@ pexpect==4.8.0
 phasespace==1.4.2
 pickleshare==0.7.5
 pillow==9.1.0
-pip-tools==6.5.1
+pip-tools==6.6.0
 platformdirs==2.5.1
 pluggy==1.0.0
 pre-commit==2.18.1
-prometheus-client==0.13.1
-prompt-toolkit==3.0.28
+prometheus-client==0.14.0
+prompt-toolkit==3.0.29
 protobuf==3.20.0
 psutil==5.9.0
 ptyprocess==0.7.0
@@ -163,7 +164,7 @@ pydata-sphinx-theme==0.8.1
 pydocstyle==6.1.1
 pyflakes==2.4.0
 pygments==2.11.2
-pylint==2.13.4 ; python_version >= "3.7.0"
+pylint==2.13.5 ; python_version >= "3.7.0"
 pyparsing==3.0.7
 pyrsistent==0.18.1
 pytest==7.1.1
@@ -191,7 +192,7 @@ six==1.16.0
 smmap==5.0.0
 sniffio==1.2.0
 snowballstemmer==2.2.0
-soupsieve==2.3.1
+soupsieve==2.3.2
 sphinx==4.3.2 ; python_version < "3.8.0"
 sphinx-autobuild==2021.3.14
 sphinx-book-theme==0.3.2
@@ -208,7 +209,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphobjinv==2.2.2
-sqlalchemy==1.4.34
+sqlalchemy==1.4.35
 sympy==1.10.1
 tensorboard==2.8.0
 tensorboard-data-server==0.6.1
@@ -231,7 +232,7 @@ types-docutils==0.18.0
 types-pkg-resources==0.1.3
 types-pyyaml==6.0.5
 types-requests==2.27.16
-types-setuptools==57.4.11
+types-setuptools==57.4.12
 types-urllib3==1.26.11
 typing-extensions==4.1.1
 urllib3==1.26.9

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -58,7 +58,7 @@ fonttools==4.31.2
 gast==0.4.0
 gitdb==4.0.9
 gitpython==3.1.27
-google-auth==2.6.2
+google-auth==2.6.3
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.19.1
@@ -79,8 +79,8 @@ ipython==8.2.0
 ipython-genutils==0.2.0
 ipywidgets==7.7.0
 isort==5.10.1
-jax==0.3.4
-jaxlib==0.3.2
+jax==0.3.5
+jaxlib==0.3.5
 jedi==0.18.1
 jinja2==3.1.1
 json5==0.9.6

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -140,13 +140,11 @@ pandocfilters==1.5.0
 parso==0.8.3
 particle==0.20.1
 pathspec==0.9.0
-pep517==0.12.0
 pep8-naming==0.12.1
 pexpect==4.8.0
 phasespace==1.4.2
 pickleshare==0.7.5
 pillow==9.1.0
-pip-tools==6.6.0
 platformdirs==2.5.1
 pluggy==1.0.0
 pre-commit==2.18.1
@@ -249,5 +247,4 @@ wrapt==1.14.0
 zipp==3.8.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -6,7 +6,7 @@
 #
 absl-py==1.0.0
 alabaster==0.7.12
-ampform==0.13.3
+ampform==0.14.0
 anyio==3.5.0
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==21.3.0
@@ -19,7 +19,7 @@ babel==2.9.1
 backcall==0.2.0
 beautifulsoup4==4.10.0
 black==22.3.0 ; python_version >= "3.7.0"
-bleach==4.1.0
+bleach==5.0.0
 cachetools==5.0.0
 certifi==2021.10.8
 cffi==1.15.0
@@ -40,6 +40,7 @@ docutils==0.17.1
 entrypoints==0.4
 execnet==1.9.0
 executing==0.8.3
+fastjsonschema==2.15.3
 filelock==3.6.0
 flake8==4.0.1
 flake8-blind-except==0.2.1
@@ -72,7 +73,7 @@ iminuit==2.11.2
 importlib-metadata==4.11.3
 importlib-resources==5.6.0
 iniconfig==1.1.1
-ipykernel==6.11.0
+ipykernel==6.12.1
 ipympl==0.8.8
 ipython==8.2.0
 ipython-genutils==0.2.0
@@ -86,13 +87,13 @@ json5==0.9.6
 jsonschema==4.4.0
 jupyter==1.0.0
 jupyter-cache==0.4.3
-jupyter-client==7.2.1
+jupyter-client==7.2.2
 jupyter-console==6.4.3
 jupyter-core==4.9.2
 jupyter-server==1.16.0
 jupyter-server-mathjax==0.2.5
 jupyter-sphinx==0.3.2
-jupyterlab==3.3.2
+jupyterlab==3.3.3
 jupyterlab-code-formatter==1.4.10
 jupyterlab-markup==1.0.1
 jupyterlab-myst==0.1.6 ; python_version >= "3.7.0"
@@ -123,7 +124,7 @@ nbclassic==0.3.7
 nbclient==0.5.13
 nbconvert==6.4.5
 nbdime==3.1.1
-nbformat==5.2.0
+nbformat==5.3.0
 nbmake==1.3.0
 nest-asyncio==1.5.5
 nodeenv==1.6.0
@@ -145,12 +146,12 @@ pexpect==4.8.0
 phasespace==1.4.2
 pickleshare==0.7.5
 pillow==9.1.0
-pip-tools==6.5.1
+pip-tools==6.6.0
 platformdirs==2.5.1
 pluggy==1.0.0
 pre-commit==2.18.1
-prometheus-client==0.13.1
-prompt-toolkit==3.0.28
+prometheus-client==0.14.0
+prompt-toolkit==3.0.29
 protobuf==3.20.0
 psutil==5.9.0
 ptyprocess==0.7.0
@@ -166,7 +167,7 @@ pydata-sphinx-theme==0.8.1
 pydocstyle==6.1.1
 pyflakes==2.4.0
 pygments==2.11.2
-pylint==2.13.4 ; python_version >= "3.7.0"
+pylint==2.13.5 ; python_version >= "3.7.0"
 pyparsing==3.0.7
 pyrsistent==0.18.1
 pytest==7.1.1
@@ -193,7 +194,7 @@ six==1.16.0
 smmap==5.0.0
 sniffio==1.2.0
 snowballstemmer==2.2.0
-soupsieve==2.3.1
+soupsieve==2.3.2
 sphinx==4.5.0
 sphinx-autobuild==2021.3.14
 sphinx-book-theme==0.3.2
@@ -210,7 +211,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphobjinv==2.2.2
-sqlalchemy==1.4.34
+sqlalchemy==1.4.35
 stack-data==0.2.0
 sympy==1.10.1
 tensorboard==2.8.0
@@ -233,7 +234,7 @@ types-docutils==0.18.0
 types-pkg-resources==0.1.3
 types-pyyaml==6.0.5
 types-requests==2.27.16
-types-setuptools==57.4.11
+types-setuptools==57.4.12
 types-urllib3==1.26.11
 typing-extensions==4.1.1
 urllib3==1.26.9

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -17,7 +17,7 @@ astunparse==1.6.3
 attrs==21.4.0
 babel==2.9.1
 backcall==0.2.0
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.0
 black==22.3.0 ; python_version >= "3.7.0"
 bleach==5.0.0
 cachetools==5.0.0
@@ -97,7 +97,7 @@ jupyterlab==3.3.3
 jupyterlab-code-formatter==1.4.10
 jupyterlab-markup==1.0.1
 jupyterlab-myst==0.1.6 ; python_version >= "3.7.0"
-jupyterlab-pygments==0.1.2
+jupyterlab-pygments==0.2.0
 jupyterlab-server==2.12.0
 jupyterlab-widgets==1.1.0
 keras==2.7.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -139,13 +139,11 @@ pandocfilters==1.5.0
 parso==0.8.3
 particle==0.20.1
 pathspec==0.9.0
-pep517==0.12.0
 pep8-naming==0.12.1
 pexpect==4.8.0
 phasespace==1.4.2
 pickleshare==0.7.5
 pillow==9.1.0
-pip-tools==6.6.0
 platformdirs==2.5.1
 pluggy==1.0.0
 pre-commit==2.18.1
@@ -248,5 +246,4 @@ wrapt==1.14.0
 zipp==3.8.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -17,7 +17,7 @@ astunparse==1.6.3
 attrs==21.4.0
 babel==2.9.1
 backcall==0.2.0
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.0
 black==22.3.0 ; python_version >= "3.7.0"
 bleach==5.0.0
 cachetools==5.0.0
@@ -96,7 +96,7 @@ jupyterlab==3.3.3
 jupyterlab-code-formatter==1.4.10
 jupyterlab-markup==1.0.1
 jupyterlab-myst==0.1.6 ; python_version >= "3.7.0"
-jupyterlab-pygments==0.1.2
+jupyterlab-pygments==0.2.0
 jupyterlab-server==2.12.0
 jupyterlab-widgets==1.1.0
 keras==2.7.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -6,7 +6,7 @@
 #
 absl-py==1.0.0
 alabaster==0.7.12
-ampform==0.13.3
+ampform==0.14.0
 anyio==3.5.0
 aquirdturtle-collapsible-headings==3.1.0
 argon2-cffi==21.3.0
@@ -19,7 +19,7 @@ babel==2.9.1
 backcall==0.2.0
 beautifulsoup4==4.10.0
 black==22.3.0 ; python_version >= "3.7.0"
-bleach==4.1.0
+bleach==5.0.0
 cachetools==5.0.0
 certifi==2021.10.8
 cffi==1.15.0
@@ -40,6 +40,7 @@ docutils==0.17.1
 entrypoints==0.4
 execnet==1.9.0
 executing==0.8.3
+fastjsonschema==2.15.3
 filelock==3.6.0
 flake8==4.0.1
 flake8-blind-except==0.2.1
@@ -71,7 +72,7 @@ imagesize==1.3.0
 iminuit==2.11.2
 importlib-metadata==4.11.3
 iniconfig==1.1.1
-ipykernel==6.11.0
+ipykernel==6.12.1
 ipympl==0.8.8
 ipython==8.2.0
 ipython-genutils==0.2.0
@@ -85,13 +86,13 @@ json5==0.9.6
 jsonschema==4.4.0
 jupyter==1.0.0
 jupyter-cache==0.4.3
-jupyter-client==7.2.1
+jupyter-client==7.2.2
 jupyter-console==6.4.3
 jupyter-core==4.9.2
 jupyter-server==1.16.0
 jupyter-server-mathjax==0.2.5
 jupyter-sphinx==0.3.2
-jupyterlab==3.3.2
+jupyterlab==3.3.3
 jupyterlab-code-formatter==1.4.10
 jupyterlab-markup==1.0.1
 jupyterlab-myst==0.1.6 ; python_version >= "3.7.0"
@@ -122,7 +123,7 @@ nbclassic==0.3.7
 nbclient==0.5.13
 nbconvert==6.4.5
 nbdime==3.1.1
-nbformat==5.2.0
+nbformat==5.3.0
 nbmake==1.3.0
 nest-asyncio==1.5.5
 nodeenv==1.6.0
@@ -144,12 +145,12 @@ pexpect==4.8.0
 phasespace==1.4.2
 pickleshare==0.7.5
 pillow==9.1.0
-pip-tools==6.5.1
+pip-tools==6.6.0
 platformdirs==2.5.1
 pluggy==1.0.0
 pre-commit==2.18.1
-prometheus-client==0.13.1
-prompt-toolkit==3.0.28
+prometheus-client==0.14.0
+prompt-toolkit==3.0.29
 protobuf==3.20.0
 psutil==5.9.0
 ptyprocess==0.7.0
@@ -165,7 +166,7 @@ pydata-sphinx-theme==0.8.1
 pydocstyle==6.1.1
 pyflakes==2.4.0
 pygments==2.11.2
-pylint==2.13.4 ; python_version >= "3.7.0"
+pylint==2.13.5 ; python_version >= "3.7.0"
 pyparsing==3.0.7
 pyrsistent==0.18.1
 pytest==7.1.1
@@ -192,7 +193,7 @@ six==1.16.0
 smmap==5.0.0
 sniffio==1.2.0
 snowballstemmer==2.2.0
-soupsieve==2.3.1
+soupsieve==2.3.2
 sphinx==4.5.0
 sphinx-autobuild==2021.3.14
 sphinx-book-theme==0.3.2
@@ -209,7 +210,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphobjinv==2.2.2
-sqlalchemy==1.4.34
+sqlalchemy==1.4.35
 stack-data==0.2.0
 sympy==1.10.1
 tensorboard==2.8.0
@@ -232,7 +233,7 @@ types-docutils==0.18.0
 types-pkg-resources==0.1.3
 types-pyyaml==6.0.5
 types-requests==2.27.16
-types-setuptools==57.4.11
+types-setuptools==57.4.12
 types-urllib3==1.26.11
 typing-extensions==4.1.1
 urllib3==1.26.9

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -58,7 +58,7 @@ fonttools==4.31.2
 gast==0.4.0
 gitdb==4.0.9
 gitpython==3.1.27
-google-auth==2.6.2
+google-auth==2.6.3
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.19.1
@@ -78,8 +78,8 @@ ipython==8.2.0
 ipython-genutils==0.2.0
 ipywidgets==7.7.0
 isort==5.10.1
-jax==0.3.4
-jaxlib==0.3.2
+jax==0.3.5
+jaxlib==0.3.5
 jedi==0.18.1
 jinja2==3.1.1
 json5==0.9.6

--- a/.cspell.json
+++ b/.cspell.json
@@ -31,6 +31,7 @@
         ".gitpod.*",
         ".mypy.ini",
         ".pre-commit-config.yaml",
+        ".prettierignore",
         ".pydocstyle*",
         ".pylintrc",
         ".readthedocs.yml",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-ast
       - id: check-case-conflict
@@ -44,7 +44,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.118
+    rev: 0.0.119
     hooks:
       - id: check-dev-files
         args:
@@ -140,7 +140,7 @@ repos:
       - id: pydocstyle
 
   - repo: https://github.com/ComPWA/mirrors-pyright
-    rev: v1.1.234
+    rev: v1.1.235
     hooks:
       - id: pyright
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
+*.ipynb
 .cspell.json
 LICENSE

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,6 @@
   "[bibtex]": {
     "editor.formatOnSave": false
   },
-  "[ipynb]": {
-    "editor.formatOnSave": false
-  },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,7 @@ filterwarnings =
     ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning
     ignore:Passing a schema to Validator.iter_errors is deprecated.*:DeprecationWarning
     ignore:Please use `spmatrix` from the `scipy.sparse` namespace.*:DeprecationWarning
+    ignore:The .* argument to NotebookFile is deprecated.*:pytest.PytestRemovedIn8Warning
     ignore:divide by zero encountered in true_divide:RuntimeWarning
     ignore:invalid value encountered in .*:RuntimeWarning
     ignore:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ phasespace =
     %(phsp)s
 pwa =
     %(phsp)s
-    ampform >=0.12.0, <0.14  # https://github.com/ComPWA/ampform/pull/177
+    ampform >=0.12.0, <0.15  # https://github.com/ComPWA/ampform/pull/177
 scipy =
     scipy >=1
 viz =

--- a/setup.cfg
+++ b/setup.cfg
@@ -154,7 +154,6 @@ dev =
     jupyterlab
     jupyterlab-code-formatter
     jupyterlab-myst; python_version >="3.7.0"
-    pip-tools >=6.1.0  # for extras_require
     sphinx-autobuild
     tox >=1.9  # for skip_install, use_develop
 


### PR DESCRIPTION
- TensorWaves can now be installed with [AmpForm v0.14.0](https://github.com/ComPWA/ampform/releases/tag/0.14.0).
- Also removed [`pip-tools`](https://github.com/jazzband/pip-tools), since upgrading is now handled purely by [`update-pip-constraints`](https://github.com/ComPWA/update-pip-constraints).
- Fixed [this problem](https://github.com/ComPWA/tensorwaves/runs/5873479487?check_suite_focus=true#step:8:36) with pytest for notebooks.