### PR TITLE
docs: use Chew-Mandelstam in analytic continuation

### DIFF
--- a/docs/amplitude-analysis/analytic-continuation.ipynb
+++ b/docs/amplitude-analysis/analytic-continuation.ipynb
@@ -292,7 +292,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.8.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/docs/amplitude-analysis/analytic-continuation.ipynb
+++ b/docs/amplitude-analysis/analytic-continuation.ipynb
@@ -170,7 +170,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To correctly describe the dynamics for this resonance, we should use make use of {doc}`analytic continuation <ampform:usage/dynamics/analytic-continuation>`. As opposed to {ref}`compwa-step-1`, we now use {func}`~ampform.dynamics.builder.create_analytic_breit_wigner` (a relativistic Breit-Wigner with analytic continuation) instead of {func}`~ampform.dynamics.builder.create_relativistic_breit_wigner_with_ff`:"
+    "To correctly describe the dynamics for this resonance, we should use make use of {doc}`analytic continuation <ampform:usage/dynamics/analytic-continuation>`. As opposed to {ref}`compwa-step-1`, we now construct a {class}`~ampform.dynamics.builder.RelativisticBreitWignerBuilder` where we set its phase space factor to {class}`~ampform.dynamics.phasespace.PhaseSpaceFactorSWave`:"
    ]
   },
   {
@@ -179,20 +179,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from ampform.dynamics import PhaseSpaceFactorSWave\n",
     "from ampform.dynamics.builder import (\n",
-    "    create_analytic_breit_wigner,\n",
+    "    RelativisticBreitWignerBuilder,\n",
     "    create_non_dynamic_with_ff,\n",
     "    create_relativistic_breit_wigner_with_ff,\n",
     ")\n",
     "\n",
     "model_builder = ampform.get_builder(reaction)\n",
+    "analytic_breit_wigner_builder = RelativisticBreitWignerBuilder(\n",
+    "    form_factor=True,\n",
+    "    energy_dependent_width=True,\n",
+    "    phsp_factor=PhaseSpaceFactorSWave,\n",
+    ")\n",
     "model_builder.set_dynamics(\n",
     "    \"J/psi(1S)\",\n",
     "    create_non_dynamic_with_ff,\n",
     ")\n",
     "model_builder.set_dynamics(\n",
     "    \"a(0)(980)0\",\n",
-    "    create_analytic_breit_wigner,\n",
+    "    analytic_breit_wigner_builder,\n",
     ")\n",
     "model_builder.set_dynamics(\n",
     "    \"a(2)(1320)0\",\n",

--- a/docs/amplitude-analysis/analytic-continuation.ipynb
+++ b/docs/amplitude-analysis/analytic-continuation.ipynb
@@ -85,12 +85,10 @@
     "import ampform\n",
     "import graphviz\n",
     "import matplotlib.pyplot as plt\n",
-    "import pandas as pd\n",
     "import qrules\n",
     "from IPython.display import Math\n",
     "\n",
     "from tensorwaves.data import (\n",
-    "    IntensityDistributionGenerator,\n",
     "    SympyDataTransformer,\n",
     "    TFPhaseSpaceGenerator,\n",
     "    TFUniformRealNumberGenerator,\n",
@@ -229,12 +227,7 @@
     "    initial_state_mass=reaction.initial_state[-1].mass,\n",
     "    final_state_masses={i: p.mass for i, p in reaction.final_state.items()},\n",
     ")\n",
-    "data_generator = IntensityDistributionGenerator(\n",
-    "    domain_generator=phsp_generator,\n",
-    "    function=intensity,\n",
-    "    domain_transformer=helicity_transformer,\n",
-    ")\n",
-    "data_momenta = data_generator.generate(2_000, rng)"
+    "phsp_momenta = phsp_generator.generate(100_000, rng)"
    ]
   },
   {
@@ -245,7 +238,7 @@
      "source_hidden": true
     },
     "tags": [
-     "hide-cell"
+     "hide-input"
     ]
    },
    "outputs": [],
@@ -253,34 +246,24 @@
     "import numpy as np\n",
     "from matplotlib import cm\n",
     "\n",
+    "phsp = helicity_transformer(phsp_momenta)\n",
+    "intensities = np.array(intensity(phsp))\n",
+    "\n",
     "resonances = sorted(\n",
     "    reaction.get_intermediate_particles(),\n",
     "    key=lambda p: p.mass,\n",
     ")\n",
-    "\n",
     "evenly_spaced_interval = np.linspace(0, 1, len(resonances))\n",
     "colors = [cm.rainbow(x) for x in evenly_spaced_interval]\n",
     "\n",
-    "\n",
-    "def indicate_masses():\n",
-    "    plt.xlabel(\"$m_{02}$ [GeV]\")\n",
-    "    for i, p in enumerate(resonances):\n",
-    "        plt.gca().axvline(\n",
-    "            x=p.mass, linestyle=\"dotted\", label=p.name, color=colors[i]\n",
-    "        )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = helicity_transformer(data_momenta)\n",
-    "data_frame = pd.DataFrame(data)\n",
-    "data_frame[\"m_02\"].hist(bins=50, alpha=0.5, density=True)\n",
-    "indicate_masses()\n",
-    "plt.legend();"
+    "fig, ax = plt.subplots()\n",
+    "ax.set_xlabel(\"$m_{02}$ [GeV]\")\n",
+    "for p, color in zip(resonances, colors):\n",
+    "    ax.axvline(x=p.mass, linestyle=\"dotted\", label=p.name, color=color)\n",
+    "ax.set_yticks([])\n",
+    "ax.hist(phsp[\"m_02\"], bins=100, alpha=0.5, weights=intensities)\n",
+    "ax.legend()\n",
+    "plt.show()"
    ]
   }
  ],

--- a/docs/amplitude-analysis/analytic-continuation.ipynb
+++ b/docs/amplitude-analysis/analytic-continuation.ipynb
@@ -118,7 +118,7 @@
     "reaction = qrules.generate_transitions(\n",
     "    initial_state=\"D0\",\n",
     "    final_state=[\"K-\", \"K+\", \"K0\"],\n",
-    "    allowed_intermediate_particles=[\"a(0)(980)0\", \"a(2)(1320)+\"],\n",
+    "    allowed_intermediate_particles=[\"a(0)(980)0\", \"a(2)(1320)0\"],\n",
     "    formalism=\"canonical-helicity\",\n",
     ")\n",
     "dot = qrules.io.asdot(\n",
@@ -195,7 +195,7 @@
     "    create_analytic_breit_wigner,\n",
     ")\n",
     "model_builder.set_dynamics(\n",
-    "    \"a(2)(1320)+\",\n",
+    "    \"a(2)(1320)0\",\n",
     "    create_relativistic_breit_wigner_with_ff,\n",
     ")\n",
     "model = model_builder.formulate()"

--- a/docs/amplitude-analysis/analytic-continuation.ipynb
+++ b/docs/amplitude-analysis/analytic-continuation.ipynb
@@ -211,6 +211,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    ":::{margin}\n",
+    "\n",
+    "Note that we have reduced the coupling for the sub-threshold resonance $a_0(980)^0$, so that it doesn't dominate over $$\n",
+    "\n",
+    ":::\n",
+    "\n",
     "The effect can be seen once we generate data. Despite the fact that the resonance lies outside phase space, there is still a contribution to the intensity:"
    ]
   },
@@ -220,6 +226,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "for par in model.parameter_defaults:\n",
+    "    if not par.name.startswith(\"C\") or \"a_{0}(980)^{0}\" not in par.name:\n",
+    "        continue\n",
+    "    model.parameter_defaults[par] = 0.1\n",
+    "\n",
     "intensity = create_parametrized_function(\n",
     "    expression=model.expression.doit(),\n",
     "    parameters=model.parameter_defaults,\n",


### PR DESCRIPTION
Preview [here]().

Switched to [`PhaseSpaceFactorSWave`](https://ampform.readthedocs.io/en/0.14.0/api/ampform.dynamics.phasespace.html#ampform.dynamics.phasespace.PhaseSpaceFactorSWave). See comparison with normal phase space factor [here](https://ampform.readthedocs.io/en/0.14.0/usage/dynamics.html#analytic-continuation).