### PR TITLE
build: remove version limit from AmpForm

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -16,7 +16,7 @@ async-generator==1.10
 attrs==21.4.0
 babel==2.9.1
 backcall==0.2.0
-beautifulsoup4==4.11.0
+beautifulsoup4==4.11.1
 bleach==4.1.0
 cached-property==1.5.2
 cachetools==4.2.4
@@ -135,7 +135,7 @@ pillow==8.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
 pre-commit==2.17.0
-prometheus-client==0.14.0
+prometheus-client==0.14.1
 prompt-toolkit==3.0.29
 protobuf==3.19.4
 ptyprocess==0.7.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -16,7 +16,7 @@ astunparse==1.6.3
 attrs==21.4.0
 babel==2.9.1
 backcall==0.2.0
-beautifulsoup4==4.11.0
+beautifulsoup4==4.11.1
 black==22.3.0 ; python_version >= "3.7.0"
 bleach==5.0.0
 cached-property==1.5.2
@@ -52,14 +52,14 @@ flake8-pytest-style==1.6.0
 flake8-rst-docstrings==0.2.5
 flake8-use-fstring==1.3
 flatbuffers==2.0
-fonttools==4.31.2
+fonttools==4.32.0
 gast==0.4.0
 gitdb==4.0.9
 gitpython==3.1.27
 google-auth==2.6.3
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
-graphviz==0.19.1
+graphviz==0.19.2
 greenlet==1.1.2
 grpcio==1.44.0
 h5py==3.6.0
@@ -146,7 +146,7 @@ pillow==9.1.0
 platformdirs==2.5.1
 pluggy==1.0.0
 pre-commit==2.18.1
-prometheus-client==0.14.0
+prometheus-client==0.14.1
 prompt-toolkit==3.0.29
 protobuf==3.20.0
 psutil==5.9.0

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -17,7 +17,7 @@ astunparse==1.6.3
 attrs==21.4.0
 babel==2.9.1
 backcall==0.2.0
-beautifulsoup4==4.11.0
+beautifulsoup4==4.11.1
 black==22.3.0 ; python_version >= "3.7.0"
 bleach==5.0.0
 cachetools==5.0.0
@@ -54,14 +54,14 @@ flake8-rst-docstrings==0.2.5
 flake8-type-ignore==0.1.0.post2 ; python_version >= "3.8.0"
 flake8-use-fstring==1.3
 flatbuffers==2.0
-fonttools==4.31.2
+fonttools==4.32.0
 gast==0.4.0
 gitdb==4.0.9
 gitpython==3.1.27
 google-auth==2.6.3
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
-graphviz==0.19.1
+graphviz==0.19.2
 greenlet==1.1.2
 grpcio==1.44.0
 h5py==3.6.0
@@ -148,7 +148,7 @@ pillow==9.1.0
 platformdirs==2.5.1
 pluggy==1.0.0
 pre-commit==2.18.1
-prometheus-client==0.14.0
+prometheus-client==0.14.1
 prompt-toolkit==3.0.29
 protobuf==3.20.0
 psutil==5.9.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -17,7 +17,7 @@ astunparse==1.6.3
 attrs==21.4.0
 babel==2.9.1
 backcall==0.2.0
-beautifulsoup4==4.11.0
+beautifulsoup4==4.11.1
 black==22.3.0 ; python_version >= "3.7.0"
 bleach==5.0.0
 cachetools==5.0.0
@@ -54,14 +54,14 @@ flake8-rst-docstrings==0.2.5
 flake8-type-ignore==0.1.0.post2 ; python_version >= "3.8.0"
 flake8-use-fstring==1.3
 flatbuffers==2.0
-fonttools==4.31.2
+fonttools==4.32.0
 gast==0.4.0
 gitdb==4.0.9
 gitpython==3.1.27
 google-auth==2.6.3
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
-graphviz==0.19.1
+graphviz==0.19.2
 greenlet==1.1.2
 grpcio==1.44.0
 h5py==3.6.0
@@ -147,7 +147,7 @@ pillow==9.1.0
 platformdirs==2.5.1
 pluggy==1.0.0
 pre-commit==2.18.1
-prometheus-client==0.14.0
+prometheus-client==0.14.1
 prompt-toolkit==3.0.29
 protobuf==3.20.0
 psutil==5.9.0

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,23 +19,15 @@ categories:
   - title: 🖱️ Developer Experience
     label: 🖱️ DX
 
-change-template: |
-  <details>
-  <summary>$TITLE (#$NUMBER)</summary>
-
-  $BODY
-
-  </details>
+change-template: "* $TITLE (#$NUMBER)"
 
 replacers:
-  - search: /<summary>([a-z]+!?:\s*)(.*)</summary>/g
-    replace: <summary>$2</summary>
+  - search: /([a-z]+!?:\s*)(.*)/g
+    replace: $2
 
 sort-direction: ascending
 
 template: |
   # Release $NEXT_PATCH_VERSION
-
-  See all documentation for this version [here](https://tensorwaves.rtfd.io/en/$NEXT_PATCH_VERSION).
 
   $CHANGES

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,7 +145,7 @@ repos:
       - id: pyright
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v2.32.0
     hooks:
       - id: pyupgrade
         args:

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ phasespace =
     %(phsp)s
 pwa =
     %(phsp)s
-    ampform >=0.12.0, <0.15  # https://github.com/ComPWA/ampform/pull/177
+    ampform >=0.12.0  # https://github.com/ComPWA/ampform/pull/177
 scipy =
     scipy >=1
 viz =


### PR DESCRIPTION
Should have been done in #424, so that there is no need to make a new TensorWaves once AmpForm is updated. With the currentl design, AmpForm and TensorWaves are separated enough that the releases don't need to be tunded.

---

Also simplifies the release notes through https://github.com/ComPWA/repo-maintenance/issues/55.