### PR TITLE
feat: lambdify Sympy.indexed expressions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,7 +19,7 @@ categories:
   - title: 🖱️ Developer Experience
     label: 🖱️ DX
 
-change-template: "* $TITLE (#$NUMBER)"
+change-template: "- $TITLE (#$NUMBER)"
 
 replacers:
   - search: /([a-z]+!?:\s*)(.*)/g

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,7 +27,4 @@ replacers:
 
 sort-direction: ascending
 
-template: |
-  # Release $NEXT_PATCH_VERSION
-
-  $CHANGES
+template: $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,4 +27,7 @@ replacers:
 
 sort-direction: ascending
 
-template: $CHANGES
+template: |
+  _See all documentation for this version [here](https://tensorwaves.rtfd.io/en/$NEXT_PATCH_VERSION)._
+
+  $CHANGES

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ addopts =
     -m "not slow"
 filterwarnings =
     error
+    ignore:.* is deprecated and will be removed in Pillow 10.*:DeprecationWarning
     ignore:.*Using or importing the ABCs.*:DeprecationWarning
     ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning
     ignore:Passing a schema to Validator.iter_errors is deprecated.*:DeprecationWarning

--- a/src/tensorwaves/data/transform.py
+++ b/src/tensorwaves/data/transform.py
@@ -3,7 +3,10 @@
 from typing import TYPE_CHECKING, Dict, Mapping, Optional, Set
 
 from tensorwaves.function import PositionalArgumentFunction
-from tensorwaves.function.sympy import _lambdify_normal_or_fast
+from tensorwaves.function.sympy import (
+    _get_free_symbols,
+    _lambdify_normal_or_fast,
+)
 from tensorwaves.interface import DataSample, DataTransformer, Function
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -53,7 +56,7 @@ class SympyDataTransformer(DataTransformer):
         }
         free_symbols: Set["sp.Symbol"] = set()
         for expr in expanded_expressions.values():
-            free_symbols |= expr.free_symbols  # type: ignore[misc]
+            free_symbols |= _get_free_symbols(expr)
         ordered_symbols = tuple(sorted(free_symbols, key=lambda s: s.name))
         argument_order = tuple(map(str, ordered_symbols))
         functions = {}

--- a/tests/function/test_sympy.py
+++ b/tests/function/test_sympy.py
@@ -91,6 +91,14 @@ def test_create_function(backend: str):
 
 
 @pytest.mark.parametrize("backend", ["jax", "math", "numpy", "tf"])
+def test_create_function_indexed_symbol(backend: str):
+    a = sp.IndexedBase("A")
+    expr = a[0] ** 2 + a[1] ** 2
+    func = create_function(expr, backend=backend)
+    assert func.argument_order == ("A[0]", "A[1]")
+
+
+@pytest.mark.parametrize("backend", ["jax", "math", "numpy", "tf"])
 @pytest.mark.parametrize("max_complexity", [0, 1, 2, 3, 4, 5])
 @pytest.mark.parametrize("use_cse", [False, True])
 def test_fast_lambdify(backend: str, max_complexity: int, use_cse: bool):


### PR DESCRIPTION
Previously, it was not possible to lambdify SymPy expressions that contain [`sympy.Indexed`](https://docs.sympy.org/latest/modules/tensor/indexed.html#sympy.tensor.indexed.Indexed) symbols (see [TR-008](https://compwa-org.readthedocs.io/report/008.html)). This PR makes it possible to use such expressions with [`create_function()`]() and related functions.