### PR TITLE
docs: improve docstrings of `function` module

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -178,6 +178,7 @@
         "lambdification",
         "lambdified",
         "lambdify",
+        "lambdifygenerated",
         "linestyle",
         "linewidth",
         "linkcheck",

--- a/.flake8
+++ b/.flake8
@@ -51,6 +51,7 @@ rst-roles =
     mod
     ref
 rst-directives =
+    automethod
     deprecated
     envvar
     exception

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,12 +123,6 @@ autodoc_default_options = {
     "members": True,
     "undoc-members": True,
     "show-inheritance": True,
-    "special-members": ", ".join(
-        [
-            "__call__",
-            "__eq__",
-        ]
-    ),
 }
 autodoc_member_order = "bysource"
 autodoc_type_aliases = {

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,10 +75,6 @@ Upcoming features <https://github.com/ComPWA/tensorwaves/milestones?direction=as
 Help developing <https://compwa-org.rtfd.io/en/stable/develop.html>
 ```
 
-- {ref}`Python API <modindex>`
-- {ref}`General Index <genindex>`
-- {ref}`Search <search>`
-
 ```{toctree}
 ---
 caption: Related projects

--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -323,7 +323,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The {meth}`.ParametrizedBackendFunction.__call__` takes a {class}`dict` of variable names (here, `\"x\"` only) to the value(s) that should be used in their place."
+    "The {meth}`.ParametrizedFunction.__call__` takes a {class}`dict` of variable names (here, `\"x\"` only) to the value(s) that should be used in their place."
    ]
   },
   {
@@ -503,7 +503,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First of all, we need to randomly generate values of $x$. In this simple, 1-dimensional example, we could just use a random generator like {class}`numpy.random.Generator` feed its output to the {meth}`.ParametrizedBackendFunction.__call__`. Generally, though, we want to cover $n$-dimensional cases. The class {class}`.NumpyDomainGenerator` allows us to generate such a **uniform** distribution for each variable within a certain range. It requires a {class}`.RealNumberGenerator` (here we use {class}`.NumpyUniformRNG`) and it also requires us to define boundaries for each variable in the resulting {obj}`.DataSample`."
+    "First of all, we need to randomly generate values of $x$. In this simple, 1-dimensional example, we could just use a random generator like {class}`numpy.random.Generator` feed its output to the {meth}`.ParametrizedFunction.__call__`. Generally, though, we want to cover $n$-dimensional cases. The class {class}`.NumpyDomainGenerator` allows us to generate such a **uniform** distribution for each variable within a certain range. It requires a {class}`.RealNumberGenerator` (here we use {class}`.NumpyUniformRNG`) and it also requires us to define boundaries for each variable in the resulting {obj}`.DataSample`."
    ]
   },
   {

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,7 @@ addopts =
     --ignore=docs/conf.py
     -k "not benchmark"
     -m "not slow"
+doctest_optionflags = NORMALIZE_WHITESPACE
 filterwarnings =
     error
     ignore:.* is deprecated and will be removed in Pillow 10.*:DeprecationWarning

--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -69,6 +69,8 @@ class PositionalArgumentFunction(Function):
     <https://docs.python.org/3/glossary.html#term-positional-argument>`_. Its
     :attr:`argument_order` redirect the keys in the `.DataSample` to the
     argument positions in its underlying :attr:`function`.
+
+    .. seealso:: :func:`.create_function`
     """
 
     function: Callable[..., np.ndarray] = field(validator=_validate_arguments)
@@ -84,7 +86,10 @@ class PositionalArgumentFunction(Function):
 
 
 class ParametrizedBackendFunction(ParametrizedFunction):
-    """Implements `.ParametrizedFunction` for a specific computational back-end."""
+    """Implements `.ParametrizedFunction` for a specific computational back-end.
+
+    .. seealso:: :func:`.create_parametrized_function`
+    """
 
     def __init__(
         self,
@@ -126,7 +131,17 @@ class ParametrizedBackendFunction(ParametrizedFunction):
 
 
 def get_source_code(function: Function) -> str:
-    """Get the backend source code used to compile this function."""
+    """Get the backend source code used to compile this function.
+
+    >>> import sympy as sp
+    >>> x, y = sp.symbols("x y")
+    >>> expr = x**2 + y**2
+    >>> func = create_function(expr, backend="jax", use_cse=False)
+    >>> src = get_source_code(func)
+    >>> print(src)
+    def _lambdifygenerated(x, y):
+        return x**2 + y**2
+    """
     if isinstance(
         function, (PositionalArgumentFunction, ParametrizedBackendFunction)
     ):

--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -134,6 +134,7 @@ def get_source_code(function: Function) -> str:
     """Get the backend source code used to compile this function.
 
     >>> import sympy as sp
+    >>> from tensorwaves.function.sympy import create_function
     >>> x, y = sp.symbols("x y")
     >>> expr = x**2 + y**2
     >>> func = create_function(expr, backend="jax", use_cse=False)

--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -64,8 +64,8 @@ def _to_tuple(argument_order: Iterable[str]) -> Tuple[str, ...]:
 class PositionalArgumentFunction(Function):
     """Wrapper around a function with positional arguments.
 
-    This class provides a :meth:`__call__` that can take a `.DataSample` for a
-    function with `positional arguments
+    This class provides a :meth:`~.Function.__call__` that can take a
+    `.DataSample` for a function with `positional arguments
     <https://docs.python.org/3/glossary.html#term-positional-argument>`_. Its
     :attr:`argument_order` redirect the keys in the `.DataSample` to the
     argument positions in its underlying :attr:`function`.

--- a/src/tensorwaves/interface.py
+++ b/src/tensorwaves/interface.py
@@ -36,6 +36,8 @@ class Function(ABC, Generic[InputType, OutputType]):
     `.OutputType` values (co-domain) for a given set of `.InputType` values
     (domain). Examples of `Function` are `ParametrizedFunction`, `Estimator`
     and `DataTransformer`.
+
+    .. automethod:: __call__
     """
 
     @abstractmethod
@@ -55,9 +57,11 @@ class ParametrizedFunction(Function[DataSample, np.ndarray]):
     A `ParametrizedFunction` identifies certain variables in a mathematical
     expression as **parameters**. Remaining variables are considered **domain
     variables**. Domain variables are the argument of the evaluation (see
-    :func:`~Function.__call__`), while the parameters are controlled via
-    :attr:`parameters` (getter) and :meth:`update_parameters` (setter). This
-    mechanism is especially important for an `Estimator`.
+    :func:`~ParametrizedFunction.__call__`), while the parameters are
+    controlled via :attr:`parameters` (getter) and :meth:`update_parameters`
+    (setter). This mechanism is especially important for an `Estimator`.
+
+    .. automethod:: __call__
     """
 
     @property
@@ -85,6 +89,8 @@ class Estimator(Function[Mapping[str, ParameterValue], float]):
 
     See the :mod:`.estimator` module for different implementations of this
     interface.
+
+    .. automethod:: __call__
     """
 
     def __call__(self, parameters: Mapping[str, ParameterValue]) -> float:
@@ -210,6 +216,8 @@ class RealNumberGenerator(ABC):
     """Abstract class for generating real numbers within a certain range.
 
     Implementations can be found in the `tensorwaves.data` module.
+
+    .. automethod:: __call__
     """
 
     @abstractmethod


### PR DESCRIPTION
- Added docstrings to `create_function()` and `create_parametrized_function()`
- `__eq__()` and `__call__()` methods are now hidden from the API by default