### PR TITLE
DX: colorize `sphinx-build` output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -103,7 +103,7 @@ description =
   Build documentation through Sphinx WITH output of Jupyter notebooks
 passenv = *
 setenv =
-  EXECUTE_NB = "yes"
+  EXECUTE_NB = yes
   FORCE_COLOR = yes
 
 [testenv:jax]


### PR DESCRIPTION
- Closes https://github.com/ComPWA/repo-maintenance/issues/108
- Sets `passenv = *` to make the config DRY