### PR TITLE
WIP: functional API

### DIFF
--- a/src/tensorwaves/function/__init__.py
+++ b/src/tensorwaves/function/__init__.py
@@ -106,7 +106,7 @@ class ParametrizedBackendFunction(ParametrizedFunction):
         self.__parameters = dict(parameters)
 
     def __call__(self, data: DataSample) -> np.ndarray:
-        extended_data = {**data, **self.__parameters}  # type: ignore[arg-type]
+        extended_data = {**self.__parameters, **data}  # type: ignore[arg-type]
         return self.__function(extended_data)  # type: ignore[arg-type]
 
     @property


### PR DESCRIPTION
If we swap the order of data and params, the params associated with the model are treated as defaults and can be overriden by giving them explicitly.

This (to my understanding) makes the function callable with parameters as args instead of updating the parameters in the model.

There should not be any legacy issue as I hardly doubt anyone gives _wrong_ parameter values and relies on the functionto overwrite it with the defaults?

If that's fine, I'll gladly add a quick test, changelog etc.

What do you thing @redeboer ?