### PR TITLE
FEAT: implement `git_friendly` flag for `YAMLSummary` callback

### DIFF
--- a/docs/usage/basics.ipynb
+++ b/docs/usage/basics.ipynb
@@ -718,6 +718,7 @@
     "    callback=CallbackList([\n",
     "        CSVSummary(\"traceback-1D.csv\"),\n",
     "        YAMLSummary(\"fit-result-1D.yaml\"),\n",
+    "        YAMLSummary(\"fit-result-1D-git-friendly.yaml\", git_friendly=True),\n",
     "        TFSummary(),\n",
     "    ])\n",
     ")\n",
@@ -733,12 +734,22 @@
      "source_hidden": true
     },
     "tags": [
-     "remove-cell"
+     "remove-input"
     ]
    },
    "outputs": [],
    "source": [
-    "assert fit_result.minimum_valid"
+    "import yaml\n",
+    "\n",
+    "assert fit_result.minimum_valid\n",
+    "with open(\"fit-result-1D.yaml\") as stream:\n",
+    "    yaml_result = yaml.safe_load(stream)\n",
+    "with open(\"fit-result-1D-git-friendly.yaml\") as stream:\n",
+    "    yaml_result_git = yaml.safe_load(stream)\n",
+    "assert \"time\" in yaml_result\n",
+    "assert \"time\" not in yaml_result_git\n",
+    "yaml_result.pop(\"time\")\n",
+    "assert yaml_result_git == yaml_result"
    ]
   },
   {
@@ -1285,7 +1296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -281,7 +281,14 @@ class TFSummary(Callback):
 
 
 class YAMLSummary(Callback, Loadable):
-    """Write current fit parameters and the estimator value to a YAML file."""
+    """Write current fit parameters and the estimator value to a YAML file.
+
+    Arguments:
+        filename: The name of output YAML file to write the logs to.
+        step_size: The number of function calls between each log entry.
+        git_friendly: If `True`, entries that are differ per run in reproducible fits,
+            such as :code:`time`, are omitted from the log.
+    """
 
     def __init__(
         self,

--- a/src/tensorwaves/optimizer/callbacks.py
+++ b/src/tensorwaves/optimizer/callbacks.py
@@ -283,10 +283,16 @@ class TFSummary(Callback):
 class YAMLSummary(Callback, Loadable):
     """Write current fit parameters and the estimator value to a YAML file."""
 
-    def __init__(self, filename: Path | str, step_size: int = 10) -> None:
+    def __init__(
+        self,
+        filename: Path | str,
+        step_size: int = 10,
+        git_friendly: bool = False,
+    ) -> None:
         self.__step_size = step_size
         self.__filename = filename
         self.__stream: IO | None = None
+        self.__git_friendly = git_friendly
 
     def __del__(self) -> None:
         _close_stream(self.__stream)
@@ -322,6 +328,8 @@ class YAMLSummary(Callback, Loadable):
         cast_logs["parameters"] = {
             p: _cast_value(v) for p, v in logs["parameters"].items()
         }
+        if self.__git_friendly:
+            cast_logs.pop("time", None)
         yaml.dump(
             cast_logs,
             self.__stream,

--- a/uv.lock
+++ b/uv.lock
@@ -4502,7 +4502,6 @@ wheels = [
 
 [[package]]
 name = "tensorwaves"
-version = "0.4.12"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
In reproducible fits (e.g. https://github.com/ComPWA/PWA-JPsi2pbarSigmaKS/pull/121), it can be useful to commit the fit result file. By setting `git_friendly=True` in `YAMLSummary`, entries that are not stable during a reproducible fit (like `time`) are omitted from the written YAML file.

<!-- no-lock-upgrade -->